### PR TITLE
Initial implementation: lexer, AST, parser, recovery, comments, fuzz, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: test (${{ matrix.os }} / go ${{ matrix.go }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        go: ['1.25.x', '1.26.x']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          check-latest: true
+      - run: go vet ./...
+      - run: go build ./...
+      - run: go test -race ./...
+
+  gofmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::Files need gofmt:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+  fuzz-quick:
+    name: fuzz (30s/target)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+      - run: go test -fuzz=FuzzParse$ -fuzztime=30s -run=- ./parser/
+      - run: go test -fuzz=FuzzParseWithRecovery$ -fuzztime=30s -run=- ./parser/
+      - run: go test -fuzz=FuzzParseValue$ -fuzztime=15s -run=- ./parser/
+      - run: go test -fuzz=FuzzParseType$ -fuzztime=15s -run=- ./parser/
+
+  bench:
+    name: benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+      - run: go test -run=- -bench=. -benchmem -count=3 ./parser/ | tee bench.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-output
+          path: bench.txt

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,31 @@
+name: Long fuzz
+
+on:
+  schedule:
+    - cron: '17 7 * * *'  # daily at 07:17 UTC
+  workflow_dispatch:
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - FuzzParse$
+          - FuzzParseWithRecovery$
+          - FuzzParseValue$
+          - FuzzParseType$
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+      - run: go test -fuzz=${{ matrix.target }} -fuzztime=15m -run=- ./parser/
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-failures-${{ matrix.target }}
+          path: parser/testdata/fuzz/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+go test ./...                              # run all tests
+go test -race ./...                        # race-checked (default for CI)
+go test ./parser/ -run TestParse_Foo       # one test
+go test -v ./parser/ -run TestCorpus       # full subtest output for one suite
+go test -fuzz=FuzzParse$ -fuzztime=30s -run=- ./parser/   # fuzz one target (regex must anchor)
+go test -bench=. -benchmem -run=- ./parser/                # benchmarks
+gofmt -l .                                 # must be empty before commit
+go vet ./...
+```
+
+Module path: `github.com/brian-bell/graphql-parser`. Go 1.26 floor.
+
+## Architecture
+
+Three packages with a strict dependency DAG:
+
+```
+lexer  →  ast
+parser →  ast, lexer
+```
+
+`ast/` is intentionally importable on its own — a future printer / formatter / LSP can depend on AST types without dragging in the parser.
+
+### Package responsibilities
+
+- `ast/` — `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; concrete pointer-receiver structs for every spec production; `Source`, `Position`, `Loc` (with lazy line-start index); `BlockStringValue` helper; `Walk`/`Inspect`; `SyntaxError` with the graphql-js-style snippet renderer.
+- `lexer/` — synchronous, single-token-lookahead, hand-written. `Token` carries byte offsets + a `Value` that's a sub-slice of source for `NAME`/`INT`/`FLOAT`. `STRING` tokens own their decoded value (escape-decoded and block-string-dedented at lex time, not parse time). `Lexer.PreserveComments` is the internal switch the parser flips for `WithComments`.
+- `parser/` — recursive descent. Public API is `Parse`, `ParseSource`, `ParseValue`, `ParseConstValue`, `ParseType`, plus `WithRecovery()` and `WithComments()`. Everything else (the `parser` struct, grammar productions, error helpers) is unexported.
+
+### Key invariants
+
+- **Every `*ast.Loc` covers the FULL EXTENT of its node** (`{Start, End}` byte offsets, half-open). Not just the first token. This diverges from `gqlparser` deliberately and is what makes formatters / LSPs / range-format possible. When adding a grammar production, build the `Loc` with `p.loc(start)` where `start` is the first token's `Start` and `p.lastEnd` (updated by `advance()`) is the End.
+- **`ast.SyntaxError` is the single error type** produced by both the lexer and the parser. `parser.ParseError = ast.SyntaxError` is a type alias. The rich snippet+caret rendering lives in `ast/error.go`.
+- **`Source.LocationOffset`** shifts reported line/column for fragments parsed from a larger file (e.g. `gql` template tags). Zero value means "no offset" (treated as `{1,1}`). The first-line column offset only applies on line 1; subsequent lines reset.
+- **`Source` must not be copied after first use** — it lazily builds a line-start index under `sync.Once`. Always pass `*Source`.
+- **Default mode is fail-fast and corpus-conformant.** `Bad*` nodes never appear unless `WithRecovery()` is set. Comments fields are nil unless `WithComments()` is set. Both options must be byte-additive; in particular, `comments_test.go` includes a "comments-off invariance" test asserting the AST is identical with `WithComments` off.
+
+### Recovery (`WithRecovery`)
+
+Two synchronization points:
+- **Top-level Definition**: on error, `parser/recover.go:skipToDefinitionStart` advances until the next definition-keyword, leading description, or `{` shorthand; a `BadDefinition` is appended.
+- **Selection inside a SelectionSet**: `skipToSelectionStart` advances until `NAME` / `...` / `}` / EOF; a `BadField` is appended.
+
+Value- and type-level recovery (`BadValue`, `BadType`) are wired through the AST and `ParseErrors` plumbing but not yet auto-injected. Adding them = wrap the relevant parse function with the same error-record-and-resync pattern.
+
+### Comments (`WithComments`)
+
+Tricky part: `parser.peek` and `parser.advance` drain `COMMENT` tokens into `parser.pendingLeading`. **A definition's leading comments must be captured BEFORE `parseDefinition` is called**, otherwise the first inner `FieldDefinition` (or similar) will steal them. See `parseDocument` for the pattern:
+
+```go
+defLeading := p.pendingLeading
+p.pendingLeading = nil
+def, err := p.parseDefinition()
+...
+attachLeadingComments(def, defLeading)
+```
+
+`commentGroupOf(node)` is a type-switch returning `**ast.CommentGroup` for nodes that have a `Comments` field — extend this when adding new node types that should carry trivia.
+
+### Type-system parser dispatch
+
+`parser.parseTypeSystemDefinitionOrExtension` returns `(ast.Definition, ok bool, error)`. The `ok` boolean lets `parseDefinition` distinguish "this token isn't a type-system production, fall through to the executable path" from a real syntax error. When adding a new top-level keyword, branch in this function and return `(node, true, nil)`.
+
+### Performance discipline
+
+`docs/perf.md` is load-bearing: no `regexp`, no `reflect`, no `fmt.Sprintf` on the hot path (only in `ast/error.go` snippet rendering and `parser/parser.go:describeToken`). Tokens carry byte offsets, not copied strings, for `NAME`/`INT`/`FLOAT`. `Walk` is type-switch dispatch, not reflection. `regexp`/`reflect`/`Sprintf` greps are part of the verification checklist.
+
+## Testing layout
+
+- `*_test.go` next to each file — unit tests
+- `parser/corpus_test.go` — graphql-js parser/lexer/schema-parser conformance, table-driven (extend by adding rows)
+- `parser/recover_test.go` / `parser/comments_test.go` — option-specific behavior
+- `parser/fuzz_test.go` — `FuzzParse`, `FuzzParseWithRecovery`, `FuzzParseValue`, `FuzzParseType` with shared seed corpus
+- `parser/benchmark_test.go` — tiny query, mid-size schema, large schema (50× synthesized)
+
+## Workflow
+
+- TDD per global instructions: failing test first, then implementation.
+- Branch off main; never commit or push directly to main. Current development branch is `feat/ast-loc` (which became the foundation branch despite the name; keep using it or branch from it).
+- Plan file with full design rationale: `~/.claude/plans/on-creating-a-graphql-witty-key.md` (17 locked decisions; consult before making API-shape changes).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brian Bell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ AST. Supports both grammars from the
 documents and the type-system / SDL — in three small packages:
 
 ```
-github.com/bellbm/graphql-parser/ast    // node types, Source, Position, Loc, Walk
-github.com/bellbm/graphql-parser/lexer  // tokenizer
-github.com/bellbm/graphql-parser/parser // Parse, ParseSource, ParseValue, ParseConstValue, ParseType
+github.com/brian-bell/graphql-parser/ast    // node types, Source, Position, Loc, Walk
+github.com/brian-bell/graphql-parser/lexer  // tokenizer
+github.com/brian-bell/graphql-parser/parser // Parse, ParseSource, ParseValue, ParseConstValue, ParseType
 ```
 
 Validation, execution, and printing are out of scope.
@@ -16,7 +16,7 @@ Validation, execution, and printing are out of scope.
 ## Install
 
 ```sh
-go get github.com/bellbm/graphql-parser
+go get github.com/brian-bell/graphql-parser
 ```
 
 Requires Go 1.26+.
@@ -26,7 +26,7 @@ Requires Go 1.26+.
 ### Parse a document
 
 ```go
-import "github.com/bellbm/graphql-parser/parser"
+import "github.com/brian-bell/graphql-parser/parser"
 
 doc, err := parser.Parse(`
     query GetUser($id: ID!) {
@@ -73,7 +73,7 @@ report the original file's coordinates.
 `ast.Walk` and `ast.Inspect` traverse a node depth-first in source order:
 
 ```go
-import "github.com/bellbm/graphql-parser/ast"
+import "github.com/brian-bell/graphql-parser/ast"
 
 ast.Inspect(doc, func(n ast.Node) bool {
     if f, ok := n.(*ast.Field); ok {

--- a/README.md
+++ b/README.md
@@ -1,0 +1,151 @@
+# graphql-parser
+
+A small, dependency-free Go library that parses GraphQL source text into an
+AST. Supports both grammars from the
+[October 2021 GraphQL spec](https://spec.graphql.org/October2021/) — executable
+documents and the type-system / SDL — in three small packages:
+
+```
+github.com/bellbm/graphql-parser/ast    // node types, Source, Position, Loc, Walk
+github.com/bellbm/graphql-parser/lexer  // tokenizer
+github.com/bellbm/graphql-parser/parser // Parse, ParseSource, ParseValue, ParseConstValue, ParseType
+```
+
+Validation, execution, and printing are out of scope.
+
+## Install
+
+```sh
+go get github.com/bellbm/graphql-parser
+```
+
+Requires Go 1.26+.
+
+## Usage
+
+### Parse a document
+
+```go
+import "github.com/bellbm/graphql-parser/parser"
+
+doc, err := parser.Parse(`
+    query GetUser($id: ID!) {
+        user(id: $id) { id name email }
+    }
+`)
+if err != nil { panic(err) }
+
+for _, def := range doc.Definitions {
+    // type-switch on def: *ast.OperationDefinition, *ast.FragmentDefinition,
+    // *ast.ObjectTypeDefinition, etc.
+}
+```
+
+### Parse a single value or type literal
+
+```go
+v, err := parser.ParseValue(`{ id: 1, tags: ["a", "b"] }`)
+t, err := parser.ParseType(`[String!]!`)
+```
+
+`ParseConstValue` is the const-context variant; it rejects `$variables` at
+any nesting depth. Use it for default-value parsing.
+
+### Position-rich errors
+
+Errors include a graphql-js-style source-line snippet with a caret pointer:
+
+```
+Syntax Error: Expected Name, found <EOF>.
+
+example.graphql:3:1
+2 |   field(
+3 | }
+  | ^
+```
+
+Reported line/column numbers honor `Source.LocationOffset`, so errors in a
+fragment parsed from a larger file (e.g. an embedded `gql` template tag)
+report the original file's coordinates.
+
+### Walking the AST
+
+`ast.Walk` and `ast.Inspect` traverse a node depth-first in source order:
+
+```go
+import "github.com/bellbm/graphql-parser/ast"
+
+ast.Inspect(doc, func(n ast.Node) bool {
+    if f, ok := n.(*ast.Field); ok {
+        fmt.Println(f.Name)
+    }
+    return true // continue descending
+})
+```
+
+## Options
+
+Every `Parse*` entry point accepts variadic options.
+
+### `WithRecovery`
+
+Collect multiple syntax errors instead of aborting on the first.
+
+```go
+doc, err := parser.Parse(brokenSource, parser.WithRecovery())
+if err != nil {
+    var es parser.ParseErrors
+    if errors.As(err, &es) {
+        for _, pe := range es {
+            fmt.Println(pe)
+        }
+    }
+}
+```
+
+The returned document is still populated with whatever could be parsed; the
+parser inserts `BadDefinition` and `BadField` placeholder nodes where it
+had to resynchronize. This is what an LSP wants when the user is mid-typing.
+
+### `WithComments`
+
+Attach `# ...` line comments as `Leading` trivia on AST nodes (top-level
+Definitions, FieldDefinitions, EnumValueDefinitions, InputValueDefinitions).
+
+```go
+doc, _ := parser.Parse(source, parser.WithComments())
+def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+for _, c := range def.Comments.Leading {
+    fmt.Println(c.Text)
+}
+```
+
+When this option is not set, the parser silently skips comments and the
+AST is byte-identical to the no-comments configuration.
+
+## Why this library?
+
+There are existing Go GraphQL parsers ([gqlparser](https://github.com/vektah/gqlparser),
+[graphql-go/graphql](https://github.com/graphql-go/graphql/tree/master/language)),
+and they're fine for most use cases. This library targets the gap they leave
+for tooling consumers:
+
+- **Full-extent positions.** Every `*ast.Loc` carries `{Start, End}` byte
+  offsets covering the entire node, not just its first token. Formatters,
+  LSPs, linters, and renamers all want this.
+- **Idiomatic Go AST.** Interfaces at spec union points (`Definition`,
+  `Selection`, `Value`, `Type`); concrete pointer-receiver structs
+  everywhere else. No `kind` discriminator, no nil-load-bearing fields.
+- **Recovery + comments built-in.** Both are opt-in (off by default to
+  preserve fail-fast and corpus conformance) but there's no extra package
+  to import or library to wrap.
+
+Conformance is held to a simple bar: in default fail-fast mode, the
+parser passes the ported `graphql-js` parser test corpus byte-for-byte on
+error messages.
+
+## License
+
+MIT — see [LICENSE](./LICENSE). The ported test corpus under
+`parser/testdata/graphql-js/` carries the upstream graphql-js MIT license;
+see [THIRD_PARTY_LICENSES.md](./THIRD_PARTY_LICENSES.md).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,31 @@
+# Third-party licenses
+
+## graphql-js
+
+The conformance test corpus under `parser/testdata/graphql-js/` is
+ported from the [graphql/graphql-js](https://github.com/graphql/graphql-js)
+project, which is distributed under the MIT License:
+
+```
+MIT License
+
+Copyright (c) GraphQL Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1,0 +1,37 @@
+package ast
+
+// Node is the super-interface satisfied by every AST node. The location is
+// nullable: synthetic nodes constructed by tools (codegen, transforms) may
+// have a nil Loc.
+type Node interface {
+	GetLoc() *Loc
+}
+
+// Definition is the union of all top-level definitions in a Document:
+// executable definitions (operation, fragment) and type-system definitions
+// (schema, type, directive, plus their extensions).
+type Definition interface {
+	Node
+	isDefinition()
+}
+
+// Selection is the union of items inside a SelectionSet: Field,
+// FragmentSpread, and InlineFragment, plus BadField when recovery is on.
+type Selection interface {
+	Node
+	isSelection()
+}
+
+// Value is the union of literal value nodes that may appear in arguments,
+// default values, list/object construction, and so on.
+type Value interface {
+	Node
+	isValue()
+}
+
+// Type is the union of type-reference nodes that appear in operation variable
+// declarations and type-system definitions: NamedType, ListType, NonNullType.
+type Type interface {
+	Node
+	isType()
+}

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -1,0 +1,76 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+)
+
+// Compile-time interface conformance for every concrete node type.
+var (
+	_ ast.Node = (*ast.Comment)(nil)
+
+	_ ast.Value = (*ast.IntValue)(nil)
+	_ ast.Value = (*ast.FloatValue)(nil)
+	_ ast.Value = (*ast.StringValue)(nil)
+	_ ast.Value = (*ast.BooleanValue)(nil)
+	_ ast.Value = (*ast.NullValue)(nil)
+	_ ast.Value = (*ast.EnumValue)(nil)
+	_ ast.Value = (*ast.ListValue)(nil)
+	_ ast.Value = (*ast.ObjectValue)(nil)
+	_ ast.Node  = (*ast.ObjectField)(nil)
+	_ ast.Value = (*ast.Variable)(nil)
+	_ ast.Value = (*ast.BadValue)(nil)
+
+	_ ast.Type = (*ast.NamedType)(nil)
+	_ ast.Type = (*ast.ListType)(nil)
+	_ ast.Type = (*ast.NonNullType)(nil)
+	_ ast.Type = (*ast.BadType)(nil)
+
+	_ ast.Selection  = (*ast.BadField)(nil)
+	_ ast.Definition = (*ast.BadDefinition)(nil)
+)
+
+func TestNode_GetLocReturnsField(t *testing.T) {
+	loc := &ast.Loc{Start: 1, End: 4}
+	cases := []ast.Node{
+		&ast.IntValue{Value: "1", Loc: loc},
+		&ast.FloatValue{Value: "1.0", Loc: loc},
+		&ast.StringValue{Value: "x", Loc: loc},
+		&ast.BooleanValue{Value: true, Loc: loc},
+		&ast.NullValue{Loc: loc},
+		&ast.EnumValue{Value: "X", Loc: loc},
+		&ast.ListValue{Loc: loc},
+		&ast.ObjectValue{Loc: loc},
+		&ast.ObjectField{Name: "a", Loc: loc},
+		&ast.Variable{Name: "v", Loc: loc},
+		&ast.NamedType{Name: "T", Loc: loc},
+		&ast.ListType{Loc: loc},
+		&ast.NonNullType{Loc: loc},
+		&ast.BadValue{Loc: loc},
+		&ast.BadType{Loc: loc},
+		&ast.BadField{Loc: loc},
+		&ast.BadDefinition{Loc: loc},
+		&ast.Comment{Text: "x", Loc: loc},
+	}
+	for i, n := range cases {
+		if got := n.GetLoc(); got != loc {
+			t.Errorf("node %d (%T).GetLoc() != stored Loc", i, n)
+		}
+	}
+}
+
+func TestNode_NilLoc(t *testing.T) {
+	// Synthetic nodes with nil Loc are legal.
+	v := &ast.IntValue{Value: "0"}
+	if v.GetLoc() != nil {
+		t.Errorf("expected nil Loc, got %v", v.GetLoc())
+	}
+}
+
+func TestCommentGroup_ZeroValue(t *testing.T) {
+	var g ast.CommentGroup
+	if len(g.Leading) != 0 || len(g.Trailing) != 0 {
+		t.Error("zero-value CommentGroup should have empty lists")
+	}
+}

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -3,7 +3,7 @@ package ast_test
 import (
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/ast"
 )
 
 // Compile-time interface conformance for every concrete node type.

--- a/ast/bad.go
+++ b/ast/bad.go
@@ -1,0 +1,40 @@
+package ast
+
+// BadValue is a placeholder Value produced by the parser in WithRecovery mode
+// when a value expression failed to parse. Err captures why; Loc covers the
+// span of source the parser consumed before resynchronizing.
+type BadValue struct {
+	Err *SyntaxError
+	Loc *Loc
+}
+
+func (v *BadValue) GetLoc() *Loc { return v.Loc }
+func (*BadValue) isValue()       {}
+
+// BadType is a placeholder Type for recovery.
+type BadType struct {
+	Err *SyntaxError
+	Loc *Loc
+}
+
+func (t *BadType) GetLoc() *Loc { return t.Loc }
+func (*BadType) isType()        {}
+
+// BadField is a placeholder Selection for recovery — used when a selection
+// inside a SelectionSet failed to parse.
+type BadField struct {
+	Err *SyntaxError
+	Loc *Loc
+}
+
+func (f *BadField) GetLoc() *Loc { return f.Loc }
+func (*BadField) isSelection()   {}
+
+// BadDefinition is a placeholder top-level Definition for recovery.
+type BadDefinition struct {
+	Err *SyntaxError
+	Loc *Loc
+}
+
+func (d *BadDefinition) GetLoc() *Loc { return d.Loc }
+func (*BadDefinition) isDefinition()  {}

--- a/ast/blockstring.go
+++ b/ast/blockstring.go
@@ -1,0 +1,88 @@
+package ast
+
+import "strings"
+
+// BlockStringValue applies the GraphQL spec's BlockStringValue algorithm to
+// the raw text between """ delimiters: it removes the common leading
+// whitespace from all lines except the first, trims leading and trailing
+// blank lines, and joins the result with '\n'. Line terminators (\n, \r, \r\n)
+// are normalized to '\n' in the output.
+func BlockStringValue(raw string) string {
+	lines := splitBlockLines(raw)
+
+	// Find the common indent across all lines except the first.
+	commonIndent := -1
+	for i := 1; i < len(lines); i++ {
+		indent := leadingWhitespaceLen(lines[i])
+		if indent < len(lines[i]) { // non-blank line
+			if commonIndent == -1 || indent < commonIndent {
+				commonIndent = indent
+				if commonIndent == 0 {
+					break
+				}
+			}
+		}
+	}
+
+	// Strip common indent from non-first lines.
+	if commonIndent > 0 {
+		for i := 1; i < len(lines); i++ {
+			line := lines[i]
+			if commonIndent < len(line) {
+				lines[i] = line[commonIndent:]
+			} else {
+				lines[i] = ""
+			}
+		}
+	}
+
+	// Trim leading and trailing blank lines.
+	for len(lines) > 0 && isBlankLine(lines[0]) {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && isBlankLine(lines[len(lines)-1]) {
+		lines = lines[:len(lines)-1]
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// splitBlockLines splits s on any of \n, \r, \r\n.
+func splitBlockLines(s string) []string {
+	var out []string
+	start, i := 0, 0
+	for i < len(s) {
+		switch s[i] {
+		case '\n':
+			out = append(out, s[start:i])
+			i++
+			start = i
+		case '\r':
+			out = append(out, s[start:i])
+			i++
+			if i < len(s) && s[i] == '\n' {
+				i++
+			}
+			start = i
+		default:
+			i++
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
+// leadingWhitespaceLen returns the byte length of the leading run of spaces
+// and tabs in line.
+func leadingWhitespaceLen(line string) int {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	return i
+}
+
+// isBlankLine reports whether line consists entirely of spaces and tabs.
+func isBlankLine(line string) bool {
+	return leadingWhitespaceLen(line) == len(line)
+}

--- a/ast/blockstring_test.go
+++ b/ast/blockstring_test.go
@@ -1,0 +1,88 @@
+package ast
+
+import "testing"
+
+func TestBlockStringValue(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single line", "hello", "hello"},
+		{"first line indent preserved", "  hello", "  hello"},
+		{
+			"strips common indent of non-first lines",
+			"\n    Hello,\n      World!\n\n    Yours,\n      GraphQL.\n  ",
+			"Hello,\n  World!\n\nYours,\n  GraphQL.",
+		},
+		{
+			"removes blank leading and trailing lines",
+			"\n\n  Hello,\n    World!\n\n\n",
+			"Hello,\n  World!",
+		},
+		{
+			"keeps blank lines in the middle",
+			"\n  Hello,\n\n  World!\n",
+			"Hello,\n\nWorld!",
+		},
+		{
+			"first-line indent excluded from common-indent calculation",
+			"      Hello,\n    World!",
+			"      Hello,\nWorld!",
+		},
+		{
+			"lone CR is a line terminator",
+			"\r  Hello,\r    World!\r",
+			"Hello,\n  World!",
+		},
+		{
+			"CRLF normalized to LF",
+			"\r\n  Hello,\r\n    World!\r\n",
+			"Hello,\n  World!",
+		},
+		{
+			"mixed terminators",
+			"\n  a\r\n  b\r  c\n",
+			"a\nb\nc",
+		},
+		{
+			"tabs count as one indent character each",
+			"\n\thello\n\tworld",
+			"hello\nworld",
+		},
+		{
+			"only whitespace lines are blank",
+			"\n   \n  hello\n   \n",
+			"hello",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := BlockStringValue(c.raw)
+			if got != c.want {
+				t.Errorf("BlockStringValue(%q):\ngot  %q\nwant %q", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestBlockStringValue_FixedPoints(t *testing.T) {
+	// Inputs that are already in their canonical block-string-value form
+	// should pass through unchanged. Note that the spec algorithm is NOT
+	// idempotent in general — re-running on a result like "a\n  b" would
+	// strip the 2-space continuation indent — so we only test inputs whose
+	// non-first lines have no leading whitespace.
+	inputs := []string{
+		"",
+		"hello",
+		"a\nb\nc",
+		"first line indented\nsecond not",
+	}
+	for _, in := range inputs {
+		got := BlockStringValue(in)
+		if got != in {
+			t.Errorf("BlockStringValue(%q) = %q; want unchanged", in, got)
+		}
+	}
+}

--- a/ast/comment.go
+++ b/ast/comment.go
@@ -1,0 +1,19 @@
+package ast
+
+// Comment is a single # ... line of comment text. Text is everything after
+// the # up to (but not including) the line terminator.
+type Comment struct {
+	Text string
+	Loc  *Loc
+}
+
+// GetLoc returns the comment's location.
+func (c *Comment) GetLoc() *Loc { return c.Loc }
+
+// CommentGroup attaches a node's leading and trailing comments. It is set on
+// AST nodes only when the parser is run with the WithComments option;
+// otherwise the field on each node is nil.
+type CommentGroup struct {
+	Leading  []*Comment
+	Trailing []*Comment
+}

--- a/ast/document.go
+++ b/ast/document.go
@@ -1,0 +1,58 @@
+package ast
+
+// Document is the top-level AST node — a sequence of one or more Definitions.
+//
+// Per spec, a Document may contain a mix of executable definitions
+// (operations, fragments) and type-system definitions/extensions; the parser
+// does not enforce a "queries only" or "schema only" partitioning.
+type Document struct {
+	Definitions DefinitionList
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+// GetLoc returns the document's location.
+func (d *Document) GetLoc() *Loc { return d.Loc }
+
+// DefinitionList is a slice of Definition with helper methods.
+type DefinitionList []Definition
+
+// ArgumentList is a slice of *Argument.
+type ArgumentList []*Argument
+
+// ForName returns the first argument named name, or nil if none exists.
+func (al ArgumentList) ForName(name string) *Argument {
+	for _, a := range al {
+		if a.Name == name {
+			return a
+		}
+	}
+	return nil
+}
+
+// DirectiveList is a slice of *Directive.
+type DirectiveList []*Directive
+
+// ForName returns the first directive named name, or nil if none exists.
+func (dl DirectiveList) ForName(name string) *Directive {
+	for _, d := range dl {
+		if d.Name == name {
+			return d
+		}
+	}
+	return nil
+}
+
+// VariableDefinitionList is a slice of *VariableDefinition.
+type VariableDefinitionList []*VariableDefinition
+
+// ForName returns the first variable definition matching name (with no
+// leading '$'), or nil if none exists.
+func (vl VariableDefinitionList) ForName(name string) *VariableDefinition {
+	for _, v := range vl {
+		if v.Variable != nil && v.Variable.Name == name {
+			return v
+		}
+	}
+	return nil
+}

--- a/ast/error.go
+++ b/ast/error.go
@@ -1,0 +1,30 @@
+package ast
+
+import "fmt"
+
+// SyntaxError is a syntax-level error tied to a byte offset in a [Source].
+// It is the common error type produced by the lexer and parser; the parser's
+// public ParseError wraps or aliases it. Phase 8 enhances Error() with a
+// graphql-js-style source-line snippet and caret pointer.
+type SyntaxError struct {
+	Source  *Source
+	Offset  int
+	Message string
+}
+
+// Error returns "<name> (<line>:<column>): <message>".
+func (e *SyntaxError) Error() string {
+	name := "GraphQL"
+	if e.Source != nil && e.Source.Name != "" {
+		name = e.Source.Name
+	}
+	return fmt.Sprintf("%s (%s): %s", name, e.Position(), e.Message)
+}
+
+// Position returns the 1-based line/column of the error.
+func (e *SyntaxError) Position() Position {
+	if e.Source == nil {
+		return Position{}
+	}
+	return e.Source.PositionAt(e.Offset)
+}

--- a/ast/error.go
+++ b/ast/error.go
@@ -1,30 +1,159 @@
 package ast
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
 
 // SyntaxError is a syntax-level error tied to a byte offset in a [Source].
 // It is the common error type produced by the lexer and parser; the parser's
-// public ParseError wraps or aliases it. Phase 8 enhances Error() with a
-// graphql-js-style source-line snippet and caret pointer.
+// public ParseError is an alias for it.
+//
+// Error() renders a graphql-js-style message:
+//
+//	Syntax Error: <message>
+//
+//	<source.Name>:<line>:<col>
+//	N - 1 | <preceding line>
+//	N     | <offending line>
+//	      |     ^
+//	N + 1 | <following line>
+//
+// LocationOffset on the Source shifts the displayed line numbers and the
+// first-line column, so errors in fragments parsed out of larger files
+// report the original file's coordinates.
 type SyntaxError struct {
 	Source  *Source
 	Offset  int
 	Message string
 }
 
-// Error returns "<name> (<line>:<column>): <message>".
+// Error renders a multi-line, graphql-js-style error message.
 func (e *SyntaxError) Error() string {
-	name := "GraphQL"
-	if e.Source != nil && e.Source.Name != "" {
-		name = e.Source.Name
+	if e.Source == nil {
+		return "Syntax Error: " + e.Message
 	}
-	return fmt.Sprintf("%s (%s): %s", name, e.Position(), e.Message)
+	pos := e.Position()
+	name := e.Source.Name
+	if name == "" {
+		name = "GraphQL"
+	}
+	snippet := e.Source.snippetAt(e.Offset)
+	if snippet == "" {
+		return fmt.Sprintf("Syntax Error: %s\n\n%s:%s", e.Message, name, pos)
+	}
+	return fmt.Sprintf("Syntax Error: %s\n\n%s:%s\n%s", e.Message, name, pos, snippet)
 }
 
-// Position returns the 1-based line/column of the error.
+// Position returns the 1-based line/column of the error, with [Source.LocationOffset]
+// applied.
 func (e *SyntaxError) Position() Position {
 	if e.Source == nil {
 		return Position{}
 	}
 	return e.Source.PositionAt(e.Offset)
+}
+
+// snippetAt returns up to three lines of source context around offset, with
+// reported line numbers in the gutter and a caret aligned beneath offset.
+func (s *Source) snippetAt(offset int) string {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(s.Body) {
+		offset = len(s.Body)
+	}
+	s.once.Do(s.computeLineStarts)
+	if len(s.lineStarts) == 0 {
+		return ""
+	}
+
+	// Raw (unshifted) line/column.
+	rawLine := lineNumberFor(s.lineStarts, offset)
+	lineStart := s.lineStarts[rawLine-1]
+	rawColumn := utf8.RuneCountInString(s.Body[lineStart:offset]) + 1
+
+	off := s.LocationOffset
+	if off.Line == 0 && off.Column == 0 {
+		off = Position{Line: 1, Column: 1}
+	}
+	displayLine := func(raw int) int { return raw + off.Line - 1 }
+	displayColumn := func(raw, rawL int) int {
+		if rawL == 1 {
+			return raw + off.Column - 1
+		}
+		return raw
+	}
+
+	type ctxLine struct {
+		num     int
+		text    string
+		isError bool
+	}
+	var lines []ctxLine
+	if rawLine > 1 {
+		lines = append(lines, ctxLine{num: displayLine(rawLine - 1), text: s.lineText(rawLine - 1)})
+	}
+	lines = append(lines, ctxLine{num: displayLine(rawLine), text: s.lineText(rawLine), isError: true})
+	if rawLine < len(s.lineStarts) {
+		lines = append(lines, ctxLine{num: displayLine(rawLine + 1), text: s.lineText(rawLine + 1)})
+	}
+
+	gutterWidth := len(strconv.Itoa(lines[len(lines)-1].num))
+	caretCol := displayColumn(rawColumn, rawLine)
+
+	var sb strings.Builder
+	for _, l := range lines {
+		ns := strconv.Itoa(l.num)
+		sb.WriteString(strings.Repeat(" ", gutterWidth-len(ns)))
+		sb.WriteString(ns)
+		sb.WriteString(" | ")
+		sb.WriteString(l.text)
+		sb.WriteString("\n")
+		if l.isError {
+			sb.WriteString(strings.Repeat(" ", gutterWidth))
+			sb.WriteString(" | ")
+			if caretCol > 1 {
+				sb.WriteString(strings.Repeat(" ", caretCol-1))
+			}
+			sb.WriteString("^")
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+// lineNumberFor returns the 1-based line number containing offset, given a
+// pre-computed line-start table.
+func lineNumberFor(lineStarts []int, offset int) int {
+	lo, hi := 0, len(lineStarts)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if lineStarts[mid] <= offset {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}
+
+// lineText returns the text of a 1-based line, stripped of its terminator.
+func (s *Source) lineText(line int) string {
+	if line < 1 || line > len(s.lineStarts) {
+		return ""
+	}
+	start := s.lineStarts[line-1]
+	var end int
+	if line < len(s.lineStarts) {
+		end = s.lineStarts[line]
+		for end > start && (s.Body[end-1] == '\n' || s.Body[end-1] == '\r') {
+			end--
+		}
+	} else {
+		end = len(s.Body)
+	}
+	return s.Body[start:end]
 }

--- a/ast/error_test.go
+++ b/ast/error_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/ast"
 )
 
 func TestSyntaxError_Header(t *testing.T) {

--- a/ast/error_test.go
+++ b/ast/error_test.go
@@ -1,0 +1,129 @@
+package ast_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+)
+
+func TestSyntaxError_Header(t *testing.T) {
+	src := &ast.Source{Body: "foo bar baz", Name: "x.graphql"}
+	e := &ast.SyntaxError{Source: src, Offset: 4, Message: "boom"}
+	got := e.Error()
+	if !strings.Contains(got, "Syntax Error: boom") {
+		t.Errorf("error %q missing 'Syntax Error: boom'", got)
+	}
+	if !strings.Contains(got, "x.graphql:1:5") {
+		t.Errorf("error %q missing 'x.graphql:1:5'", got)
+	}
+}
+
+func TestSyntaxError_Snippet_SingleLine(t *testing.T) {
+	src := &ast.Source{Body: "foo bar baz", Name: "x.graphql"}
+	e := &ast.SyntaxError{Source: src, Offset: 4, Message: "expected EOF"}
+	got := e.Error()
+	if !strings.Contains(got, "1 | foo bar baz") {
+		t.Errorf("error %q missing the offending line", got)
+	}
+	// Caret should be aligned under "b" in "bar" (column 5).
+	if !strings.Contains(got, "  |     ^") {
+		t.Errorf("error %q has misaligned caret", got)
+	}
+}
+
+func TestSyntaxError_Snippet_WithContext(t *testing.T) {
+	src := &ast.Source{
+		Body: "line1\nline2 with error\nline3",
+		Name: "x",
+	}
+	// Offset of 'w' in "with" on line 2 is 12.
+	e := &ast.SyntaxError{Source: src, Offset: 12, Message: "boom"}
+	got := e.Error()
+	for _, want := range []string{"1 | line1", "2 | line2 with error", "3 | line3"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error\n%s\nmissing %q", got, want)
+		}
+	}
+}
+
+func TestSyntaxError_Snippet_FirstLineNoBefore(t *testing.T) {
+	src := &ast.Source{Body: "abc\ndef", Name: "x"}
+	e := &ast.SyntaxError{Source: src, Offset: 0, Message: "x"}
+	got := e.Error()
+	if !strings.Contains(got, "1 | abc") {
+		t.Errorf("missing 1 | abc in:\n%s", got)
+	}
+	if !strings.Contains(got, "2 | def") {
+		t.Errorf("missing 2 | def (after) in:\n%s", got)
+	}
+}
+
+func TestSyntaxError_Snippet_LastLineNoAfter(t *testing.T) {
+	src := &ast.Source{Body: "abc\ndef", Name: "x"}
+	// Offset 4 = 'd' on line 2.
+	e := &ast.SyntaxError{Source: src, Offset: 4, Message: "x"}
+	got := e.Error()
+	if !strings.Contains(got, "1 | abc") {
+		t.Errorf("missing line 1 in:\n%s", got)
+	}
+	if !strings.Contains(got, "2 | def") {
+		t.Errorf("missing line 2 in:\n%s", got)
+	}
+}
+
+func TestSyntaxError_NilSource(t *testing.T) {
+	e := &ast.SyntaxError{Message: "no source"}
+	got := e.Error()
+	if !strings.Contains(got, "no source") {
+		t.Errorf("error %q missing message", got)
+	}
+}
+
+func TestSyntaxError_LocationOffset(t *testing.T) {
+	// Source claims to start at line 10, column 5 of a larger file.
+	src := &ast.Source{
+		Body:           "abc\ndef",
+		Name:           "x",
+		LocationOffset: ast.Position{Line: 10, Column: 5},
+	}
+	// Offset 0 → reported as line 10, col 5.
+	e := &ast.SyntaxError{Source: src, Offset: 0, Message: "x"}
+	got := e.Error()
+	if !strings.Contains(got, "x:10:5") {
+		t.Errorf("error %q missing shifted position 10:5", got)
+	}
+	// The gutter uses reported (shifted) line numbers.
+	if !strings.Contains(got, "10 | abc") {
+		t.Errorf("error %q does not show shifted gutter line 10", got)
+	}
+}
+
+func TestSyntaxError_OffsetAtEOF(t *testing.T) {
+	src := &ast.Source{Body: "abc", Name: "x"}
+	e := &ast.SyntaxError{Source: src, Offset: 3, Message: "expected something"}
+	// Should not panic, should include the line and a caret past the last char.
+	got := e.Error()
+	if !strings.Contains(got, "1 | abc") {
+		t.Errorf("missing line in:\n%s", got)
+	}
+}
+
+func TestSyntaxError_MultiByteRunes(t *testing.T) {
+	// "héllo world": é is 2 bytes (UTF-8 0xC3 0xA9). Bytes 0..6 = "héllo "
+	// (codepoints h é l l o space = 6 runes). Byte 7 = 'w', codepoint column 7.
+	src := &ast.Source{Body: "héllo world", Name: "x"}
+	e := &ast.SyntaxError{Source: src, Offset: 7, Message: "x"} // 'w'
+	got := e.Error()
+	if !strings.Contains(got, "x:1:7") {
+		t.Errorf("expected codepoint column 7 in:\n%s", got)
+	}
+	if !strings.Contains(got, "héllo world") {
+		t.Errorf("missing source in:\n%s", got)
+	}
+	// caretCol-1 = 6 spaces, then ^.  Format is "<gutter> | <pad><caret>".
+	// Gutter width 1 (single-digit line), so prefix is "  | " then 6 spaces.
+	if !strings.Contains(got, "  |       ^") {
+		t.Errorf("caret misaligned in:\n%s", got)
+	}
+}

--- a/ast/executable.go
+++ b/ast/executable.go
@@ -1,0 +1,128 @@
+package ast
+
+// OperationType identifies which root operation this is (query, mutation, or
+// subscription). A bare "{ ... }" shorthand operation is parsed as an
+// OperationDefinition with Operation == OperationQuery.
+type OperationType string
+
+// Operation type constants.
+const (
+	OperationQuery        OperationType = "query"
+	OperationMutation     OperationType = "mutation"
+	OperationSubscription OperationType = "subscription"
+)
+
+// OperationDefinition is a query, mutation, or subscription. Anonymous
+// operations (the "{ ... }" shorthand) have an empty Name and no
+// VariableDefinitions or Directives.
+type OperationDefinition struct {
+	Operation           OperationType
+	Name                string
+	VariableDefinitions VariableDefinitionList
+	Directives          DirectiveList
+	SelectionSet        *SelectionSet
+	Loc                 *Loc
+	Comments            *CommentGroup
+}
+
+func (d *OperationDefinition) GetLoc() *Loc { return d.Loc }
+func (*OperationDefinition) isDefinition()  {}
+
+// FragmentDefinition is a named fragment: "fragment Name on Type { ... }".
+type FragmentDefinition struct {
+	Name          string
+	TypeCondition *NamedType
+	Directives    DirectiveList
+	SelectionSet  *SelectionSet
+	Loc           *Loc
+	Comments      *CommentGroup
+}
+
+func (d *FragmentDefinition) GetLoc() *Loc { return d.Loc }
+func (*FragmentDefinition) isDefinition()  {}
+
+// VariableDefinition declares an operation variable: "$name: Type = default
+// @directive...".
+type VariableDefinition struct {
+	Variable     *Variable
+	Type         Type
+	DefaultValue Value // const value; nil if no default
+	Directives   DirectiveList
+	Loc          *Loc
+	Comments     *CommentGroup
+}
+
+func (v *VariableDefinition) GetLoc() *Loc { return v.Loc }
+
+// SelectionSet is a "{ ... }" block of one or more Selections.
+type SelectionSet struct {
+	Selections []Selection
+	Loc        *Loc
+	Comments   *CommentGroup
+}
+
+// GetLoc returns the location covering the selection set including its braces.
+func (s *SelectionSet) GetLoc() *Loc { return s.Loc }
+
+// Field is a leaf or non-leaf selection: "[alias:] name(args)? @dir...?
+// SelectionSet?".
+type Field struct {
+	Alias        string // empty when no alias was written
+	Name         string
+	Arguments    ArgumentList
+	Directives   DirectiveList
+	SelectionSet *SelectionSet // nil for leaf fields
+	Loc          *Loc
+	Comments     *CommentGroup
+}
+
+func (f *Field) GetLoc() *Loc { return f.Loc }
+func (*Field) isSelection()   {}
+
+// FragmentSpread is "...FragmentName Directives?". The name must not be "on";
+// the parser disambiguates against InlineFragment.
+type FragmentSpread struct {
+	Name       string
+	Directives DirectiveList
+	Loc        *Loc
+	Comments   *CommentGroup
+}
+
+func (s *FragmentSpread) GetLoc() *Loc { return s.Loc }
+func (*FragmentSpread) isSelection()   {}
+
+// InlineFragment is "... TypeCondition? Directives? SelectionSet". The
+// type condition is optional; when absent, the fragment inherits the
+// parent's type.
+type InlineFragment struct {
+	TypeCondition *NamedType // nil when omitted
+	Directives    DirectiveList
+	SelectionSet  *SelectionSet
+	Loc           *Loc
+	Comments      *CommentGroup
+}
+
+func (f *InlineFragment) GetLoc() *Loc { return f.Loc }
+func (*InlineFragment) isSelection()   {}
+
+// Argument is one "name: value" entry in a function-style argument list.
+type Argument struct {
+	Name     string
+	Value    Value
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (a *Argument) GetLoc() *Loc { return a.Loc }
+
+// Directive is "@name(args)?". Arguments must be const values when the
+// directive appears on a type-system definition; the parser enforces this
+// based on call site, not on the AST type.
+type Directive struct {
+	Name      string
+	Arguments ArgumentList
+	Loc       *Loc
+	Comments  *CommentGroup
+}
+
+func (d *Directive) GetLoc() *Loc { return d.Loc }

--- a/ast/loc.go
+++ b/ast/loc.go
@@ -1,0 +1,118 @@
+// Package ast defines the GraphQL abstract syntax tree, including node types,
+// source-position tracking, and traversal helpers.
+package ast
+
+import (
+	"fmt"
+	"sync"
+	"unicode/utf8"
+)
+
+// Position is a 1-based line and column into a [Source]. Columns count
+// codepoints (not bytes), matching graphql-js. The zero value (Position{}) is
+// interpreted as Position{Line: 1, Column: 1} when used as a [Source.LocationOffset].
+type Position struct {
+	Line   int // 1-based
+	Column int // 1-based, in codepoints
+}
+
+// String returns "line:column".
+func (p Position) String() string {
+	return fmt.Sprintf("%d:%d", p.Line, p.Column)
+}
+
+// Source is a GraphQL document together with an identifying name (used in
+// error messages) and an optional offset describing its location within a
+// larger file (e.g. an embedded `gql` template tag). A Source must not be
+// copied after first use; pass it by pointer.
+type Source struct {
+	// Body is the document text. Tokens hold byte offsets into this string.
+	Body string
+
+	// Name is a human-readable identifier (typically a filename) used in error
+	// messages. It is not interpreted otherwise.
+	Name string
+
+	// LocationOffset shifts reported positions so that they reference a larger
+	// containing file. The zero value is treated as Position{Line: 1, Column: 1}
+	// (no shift). Column is applied only to the first line of Body.
+	LocationOffset Position
+
+	once       sync.Once
+	lineStarts []int // byte offsets where each line begins; lineStarts[0] == 0
+}
+
+// Loc covers a half-open byte range [Start, End) into Source.Body. It describes
+// the full extent of an AST node, not just the start of its first token.
+type Loc struct {
+	Start, End int
+	Source     *Source
+}
+
+// StartPosition returns the 1-based line/column of [Loc.Start].
+func (l *Loc) StartPosition() Position { return l.Source.PositionAt(l.Start) }
+
+// EndPosition returns the 1-based line/column of [Loc.End].
+func (l *Loc) EndPosition() Position { return l.Source.PositionAt(l.End) }
+
+// PositionAt returns the 1-based {Line, Column} of the byte at offset.
+// Negative offsets are treated as 0; offsets greater than len(Body) are
+// clamped to len(Body). The first call on a given Source builds a line-start
+// index lazily; subsequent calls reuse it.
+func (s *Source) PositionAt(offset int) Position {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(s.Body) {
+		offset = len(s.Body)
+	}
+	s.once.Do(s.computeLineStarts)
+
+	// Binary search: find the largest index i such that lineStarts[i] <= offset.
+	// The 1-based line number is i+1.
+	lo, hi := 0, len(s.lineStarts)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if s.lineStarts[mid] <= offset {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	line := lo // count of starts <= offset == 1-based line number
+	lineStart := s.lineStarts[line-1]
+	column := utf8.RuneCountInString(s.Body[lineStart:offset]) + 1
+
+	return s.applyLocationOffset(Position{Line: line, Column: column})
+}
+
+func (s *Source) computeLineStarts() {
+	starts := []int{0}
+	for i := 0; i < len(s.Body); i++ {
+		switch s.Body[i] {
+		case '\n':
+			starts = append(starts, i+1)
+		case '\r':
+			if i+1 < len(s.Body) && s.Body[i+1] == '\n' {
+				starts = append(starts, i+2)
+				i++
+			} else {
+				starts = append(starts, i+1)
+			}
+		}
+	}
+	s.lineStarts = starts
+}
+
+func (s *Source) applyLocationOffset(p Position) Position {
+	off := s.LocationOffset
+	if off.Line == 0 && off.Column == 0 {
+		return p
+	}
+	line := p.Line + off.Line - 1
+	column := p.Column
+	if p.Line == 1 {
+		column = p.Column + off.Column - 1
+	}
+	return Position{Line: line, Column: column}
+}

--- a/ast/loc_test.go
+++ b/ast/loc_test.go
@@ -1,0 +1,230 @@
+package ast
+
+import "testing"
+
+func mkSource(body string) *Source {
+	return &Source{Body: body, Name: "test.graphql"}
+}
+
+func TestPositionAt_Empty(t *testing.T) {
+	s := mkSource("")
+	if got := s.PositionAt(0); got != (Position{Line: 1, Column: 1}) {
+		t.Errorf("PositionAt(0) of empty source = %+v; want {1, 1}", got)
+	}
+	if got := s.PositionAt(5); got != (Position{Line: 1, Column: 1}) {
+		t.Errorf("PositionAt(5) of empty source = %+v; want {1, 1} (clamped)", got)
+	}
+}
+
+func TestPositionAt_SingleLine(t *testing.T) {
+	s := mkSource("hello")
+	cases := []struct {
+		offset int
+		want   Position
+	}{
+		{0, Position{1, 1}},
+		{1, Position{1, 2}},
+		{4, Position{1, 5}},
+		{5, Position{1, 6}}, // EOF
+	}
+	for _, c := range cases {
+		if got := s.PositionAt(c.offset); got != c.want {
+			t.Errorf("PositionAt(%d) = %+v; want %+v", c.offset, got, c.want)
+		}
+	}
+}
+
+func TestPositionAt_LF(t *testing.T) {
+	s := mkSource("a\nb")
+	cases := []struct {
+		offset int
+		want   Position
+	}{
+		{0, Position{1, 1}},
+		{1, Position{1, 2}}, // \n
+		{2, Position{2, 1}}, // b
+		{3, Position{2, 2}}, // EOF
+	}
+	for _, c := range cases {
+		if got := s.PositionAt(c.offset); got != c.want {
+			t.Errorf("PositionAt(%d) = %+v; want %+v", c.offset, got, c.want)
+		}
+	}
+}
+
+func TestPositionAt_CRLF(t *testing.T) {
+	s := mkSource("a\r\nb")
+	// "a", "\r", "\n", "b" at offsets 0, 1, 2, 3.
+	// Line 2 starts at offset 3 (after the \r\n).
+	cases := []struct {
+		offset int
+		want   Position
+	}{
+		{0, Position{1, 1}}, // a
+		{1, Position{1, 2}}, // \r — still on line 1
+		{2, Position{1, 3}}, // \n inside the CRLF; binary-search reports the start-line
+		{3, Position{2, 1}}, // b
+		{4, Position{2, 2}}, // EOF
+	}
+	for _, c := range cases {
+		if got := s.PositionAt(c.offset); got != c.want {
+			t.Errorf("PositionAt(%d) = %+v; want %+v", c.offset, got, c.want)
+		}
+	}
+}
+
+func TestPositionAt_LoneCR(t *testing.T) {
+	s := mkSource("a\rb")
+	cases := []struct {
+		offset int
+		want   Position
+	}{
+		{0, Position{1, 1}}, // a
+		{1, Position{1, 2}}, // \r
+		{2, Position{2, 1}}, // b
+		{3, Position{2, 2}}, // EOF
+	}
+	for _, c := range cases {
+		if got := s.PositionAt(c.offset); got != c.want {
+			t.Errorf("PositionAt(%d) = %+v; want %+v", c.offset, got, c.want)
+		}
+	}
+}
+
+func TestPositionAt_NoTrailingNewline(t *testing.T) {
+	s := mkSource("foo\nbar")
+	if got := s.PositionAt(7); got != (Position{2, 4}) {
+		t.Errorf("PositionAt(7) of %q = %+v; want {2, 4}", s.Body, got)
+	}
+}
+
+func TestPositionAt_TrailingNewline(t *testing.T) {
+	s := mkSource("foo\n")
+	if got := s.PositionAt(4); got != (Position{2, 1}) {
+		t.Errorf("PositionAt(4) of %q = %+v; want {2, 1}", s.Body, got)
+	}
+}
+
+func TestPositionAt_MixedTerminators(t *testing.T) {
+	// "a\nb\r\nc\rd" — four lines: a, b, c, d
+	// Offsets:        0 1 2 3 4 5 6 7
+	s := mkSource("a\nb\r\nc\rd")
+	cases := []struct {
+		offset int
+		want   Position
+	}{
+		{0, Position{1, 1}}, // a
+		{2, Position{2, 1}}, // b
+		{5, Position{3, 1}}, // c
+		{7, Position{4, 1}}, // d
+		{8, Position{4, 2}}, // EOF
+	}
+	for _, c := range cases {
+		if got := s.PositionAt(c.offset); got != c.want {
+			t.Errorf("PositionAt(%d) = %+v; want %+v", c.offset, got, c.want)
+		}
+	}
+}
+
+func TestPositionAt_MultiByteRunes(t *testing.T) {
+	// "héllo" — é is 2 bytes (UTF-8 0xC3 0xA9). Column counts codepoints, not bytes.
+	s := mkSource("héllo")
+	cases := []struct {
+		offset int
+		want   Position
+	}{
+		{0, Position{1, 1}}, // h
+		{1, Position{1, 2}}, // é (start byte)
+		{3, Position{1, 3}}, // l (after é)
+		{4, Position{1, 4}}, // l
+		{5, Position{1, 5}}, // o
+		{6, Position{1, 6}}, // EOF
+	}
+	for _, c := range cases {
+		if got := s.PositionAt(c.offset); got != c.want {
+			t.Errorf("PositionAt(%d) = %+v; want %+v", c.offset, got, c.want)
+		}
+	}
+}
+
+func TestPositionAt_NegativeOffset(t *testing.T) {
+	s := mkSource("hi")
+	if got := s.PositionAt(-1); got != (Position{1, 1}) {
+		t.Errorf("PositionAt(-1) = %+v; want {1, 1}", got)
+	}
+}
+
+func TestPositionAt_LocationOffset_Default(t *testing.T) {
+	// Zero-value LocationOffset is treated as {1,1} (no offset).
+	s := &Source{Body: "x"}
+	if got := s.PositionAt(0); got != (Position{1, 1}) {
+		t.Errorf("PositionAt(0) with zero LocationOffset = %+v; want {1, 1}", got)
+	}
+}
+
+func TestPositionAt_LocationOffset_NonDefault(t *testing.T) {
+	s := &Source{
+		Body:           "abc\ndef",
+		LocationOffset: Position{Line: 10, Column: 5},
+	}
+	// First line: line + 10 - 1; column + 5 - 1.
+	if got := s.PositionAt(0); got != (Position{10, 5}) {
+		t.Errorf("PositionAt(0) = %+v; want {10, 5}", got)
+	}
+	if got := s.PositionAt(1); got != (Position{10, 6}) {
+		t.Errorf("PositionAt(1) = %+v; want {10, 6}", got)
+	}
+	// Second line: column does NOT inherit the Column offset; only Line is shifted.
+	if got := s.PositionAt(4); got != (Position{11, 1}) {
+		t.Errorf("PositionAt(4) = %+v; want {11, 1}", got)
+	}
+}
+
+func TestLoc_StartEndPosition(t *testing.T) {
+	s := mkSource("foo\nbarbaz")
+	// Indices: f=0 o=1 o=2 \n=3 b=4 a=5 r=6 b=7 a=8 z=9
+	loc := &Loc{Start: 4, End: 10, Source: s}
+	if got := loc.StartPosition(); got != (Position{2, 1}) {
+		t.Errorf("StartPosition() = %+v; want {2, 1}", got)
+	}
+	if got := loc.EndPosition(); got != (Position{2, 7}) {
+		t.Errorf("EndPosition() = %+v; want {2, 7}", got)
+	}
+}
+
+func TestPosition_String(t *testing.T) {
+	cases := []struct {
+		p    Position
+		want string
+	}{
+		{Position{1, 1}, "1:1"},
+		{Position{12, 34}, "12:34"},
+		{Position{}, "0:0"},
+	}
+	for _, c := range cases {
+		if got := c.p.String(); got != c.want {
+			t.Errorf("Position%+v.String() = %q; want %q", c.p, got, c.want)
+		}
+	}
+}
+
+func TestPositionAt_ConcurrentSafe(t *testing.T) {
+	// Repeated calls on the same Source must produce the same result and
+	// not race on lazy line-start computation.
+	s := mkSource("a\nb\r\nc\rd")
+	want := Position{3, 1}
+	done := make(chan struct{}, 16)
+	for range 16 {
+		go func() {
+			for range 1000 {
+				if got := s.PositionAt(5); got != want {
+					t.Errorf("PositionAt(5) = %+v; want %+v", got, want)
+				}
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range 16 {
+		<-done
+	}
+}

--- a/ast/schema.go
+++ b/ast/schema.go
@@ -1,0 +1,282 @@
+package ast
+
+// SchemaDefinition declares the root operation types of a schema.
+type SchemaDefinition struct {
+	Description    *StringValue
+	Directives     DirectiveList
+	OperationTypes []*OperationTypeDefinition
+	Loc            *Loc
+	Comments       *CommentGroup
+}
+
+func (d *SchemaDefinition) GetLoc() *Loc { return d.Loc }
+func (*SchemaDefinition) isDefinition()  {}
+
+// SchemaExtension extends a schema with additional directives and/or root
+// operation types.
+type SchemaExtension struct {
+	Directives     DirectiveList
+	OperationTypes []*OperationTypeDefinition
+	Loc            *Loc
+	Comments       *CommentGroup
+}
+
+func (d *SchemaExtension) GetLoc() *Loc { return d.Loc }
+func (*SchemaExtension) isDefinition()  {}
+
+// OperationTypeDefinition is one "query: Query" entry inside a SchemaDefinition.
+type OperationTypeDefinition struct {
+	Operation OperationType
+	Type      *NamedType
+	Loc       *Loc
+	Comments  *CommentGroup
+}
+
+func (d *OperationTypeDefinition) GetLoc() *Loc { return d.Loc }
+
+// ScalarTypeDefinition declares a custom scalar type.
+type ScalarTypeDefinition struct {
+	Description *StringValue
+	Name        string
+	Directives  DirectiveList
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *ScalarTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (*ScalarTypeDefinition) isDefinition()  {}
+
+// ScalarTypeExtension adds directives to an existing scalar type.
+type ScalarTypeExtension struct {
+	Name       string
+	Directives DirectiveList
+	Loc        *Loc
+	Comments   *CommentGroup
+}
+
+func (d *ScalarTypeExtension) GetLoc() *Loc { return d.Loc }
+func (*ScalarTypeExtension) isDefinition()  {}
+
+// ObjectTypeDefinition declares a GraphQL object type.
+type ObjectTypeDefinition struct {
+	Description *StringValue
+	Name        string
+	Interfaces  []*NamedType
+	Directives  DirectiveList
+	Fields      FieldDefinitionList
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *ObjectTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (*ObjectTypeDefinition) isDefinition()  {}
+
+// ObjectTypeExtension extends an existing object type.
+type ObjectTypeExtension struct {
+	Name       string
+	Interfaces []*NamedType
+	Directives DirectiveList
+	Fields     FieldDefinitionList
+	Loc        *Loc
+	Comments   *CommentGroup
+}
+
+func (d *ObjectTypeExtension) GetLoc() *Loc { return d.Loc }
+func (*ObjectTypeExtension) isDefinition()  {}
+
+// InterfaceTypeDefinition declares an interface type.
+type InterfaceTypeDefinition struct {
+	Description *StringValue
+	Name        string
+	Interfaces  []*NamedType
+	Directives  DirectiveList
+	Fields      FieldDefinitionList
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *InterfaceTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (*InterfaceTypeDefinition) isDefinition()  {}
+
+// InterfaceTypeExtension extends an interface type.
+type InterfaceTypeExtension struct {
+	Name       string
+	Interfaces []*NamedType
+	Directives DirectiveList
+	Fields     FieldDefinitionList
+	Loc        *Loc
+	Comments   *CommentGroup
+}
+
+func (d *InterfaceTypeExtension) GetLoc() *Loc { return d.Loc }
+func (*InterfaceTypeExtension) isDefinition()  {}
+
+// UnionTypeDefinition declares a union type: "union U = A | B | C".
+type UnionTypeDefinition struct {
+	Description *StringValue
+	Name        string
+	Directives  DirectiveList
+	Members     []*NamedType
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *UnionTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (*UnionTypeDefinition) isDefinition()  {}
+
+// UnionTypeExtension extends a union type.
+type UnionTypeExtension struct {
+	Name       string
+	Directives DirectiveList
+	Members    []*NamedType
+	Loc        *Loc
+	Comments   *CommentGroup
+}
+
+func (d *UnionTypeExtension) GetLoc() *Loc { return d.Loc }
+func (*UnionTypeExtension) isDefinition()  {}
+
+// EnumTypeDefinition declares an enum type.
+type EnumTypeDefinition struct {
+	Description *StringValue
+	Name        string
+	Directives  DirectiveList
+	Values      EnumValueList
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *EnumTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (*EnumTypeDefinition) isDefinition()  {}
+
+// EnumTypeExtension extends an enum type.
+type EnumTypeExtension struct {
+	Name       string
+	Directives DirectiveList
+	Values     EnumValueList
+	Loc        *Loc
+	Comments   *CommentGroup
+}
+
+func (d *EnumTypeExtension) GetLoc() *Loc { return d.Loc }
+func (*EnumTypeExtension) isDefinition()  {}
+
+// InputObjectTypeDefinition declares an input object type.
+type InputObjectTypeDefinition struct {
+	Description *StringValue
+	Name        string
+	Directives  DirectiveList
+	Fields      InputValueList
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *InputObjectTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (*InputObjectTypeDefinition) isDefinition()  {}
+
+// InputObjectTypeExtension extends an input object type.
+type InputObjectTypeExtension struct {
+	Name       string
+	Directives DirectiveList
+	Fields     InputValueList
+	Loc        *Loc
+	Comments   *CommentGroup
+}
+
+func (d *InputObjectTypeExtension) GetLoc() *Loc { return d.Loc }
+func (*InputObjectTypeExtension) isDefinition()  {}
+
+// FieldDefinition is one entry inside an Object or Interface type, e.g.
+// "name(args): Type @directive...".
+type FieldDefinition struct {
+	Description *StringValue
+	Name        string
+	Arguments   InputValueList
+	Type        Type
+	Directives  DirectiveList
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *FieldDefinition) GetLoc() *Loc { return d.Loc }
+
+// InputValueDefinition is used for both argument definitions (on
+// FieldDefinition / DirectiveDefinition) and input-object fields. It
+// optionally carries a const default value.
+type InputValueDefinition struct {
+	Description  *StringValue
+	Name         string
+	Type         Type
+	DefaultValue Value
+	Directives   DirectiveList
+	Loc          *Loc
+	Comments     *CommentGroup
+}
+
+func (d *InputValueDefinition) GetLoc() *Loc { return d.Loc }
+
+// EnumValueDefinition is one entry inside an EnumTypeDefinition. The Name
+// must not be true, false, or null per spec.
+type EnumValueDefinition struct {
+	Description *StringValue
+	Name        string
+	Directives  DirectiveList
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *EnumValueDefinition) GetLoc() *Loc { return d.Loc }
+
+// DirectiveDefinition declares a directive: "directive @name(args) on LOCATIONS".
+// Repeatable is true if the definition included the "repeatable" keyword.
+type DirectiveDefinition struct {
+	Description *StringValue
+	Name        string
+	Arguments   InputValueList
+	Repeatable  bool
+	Locations   []string
+	Loc         *Loc
+	Comments    *CommentGroup
+}
+
+func (d *DirectiveDefinition) GetLoc() *Loc { return d.Loc }
+func (*DirectiveDefinition) isDefinition()  {}
+
+// FieldDefinitionList is a slice of *FieldDefinition with helper methods.
+type FieldDefinitionList []*FieldDefinition
+
+// ForName returns the first field definition matching name, or nil.
+func (fl FieldDefinitionList) ForName(name string) *FieldDefinition {
+	for _, f := range fl {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// InputValueList is a slice of *InputValueDefinition.
+type InputValueList []*InputValueDefinition
+
+// ForName returns the first input value matching name, or nil.
+func (il InputValueList) ForName(name string) *InputValueDefinition {
+	for _, v := range il {
+		if v.Name == name {
+			return v
+		}
+	}
+	return nil
+}
+
+// EnumValueList is a slice of *EnumValueDefinition.
+type EnumValueList []*EnumValueDefinition
+
+// ForName returns the first enum value matching name, or nil.
+func (el EnumValueList) ForName(name string) *EnumValueDefinition {
+	for _, v := range el {
+		if v.Name == name {
+			return v
+		}
+	}
+	return nil
+}

--- a/ast/type.go
+++ b/ast/type.go
@@ -1,0 +1,30 @@
+package ast
+
+// NamedType is a bare type name like "User" or "Int".
+type NamedType struct {
+	Name string
+	Loc  *Loc
+}
+
+func (t *NamedType) GetLoc() *Loc { return t.Loc }
+func (*NamedType) isType()        {}
+
+// ListType is a [T] type. OfType is the inner type, which may itself be any
+// Type (NamedType, ListType, or NonNullType).
+type ListType struct {
+	OfType Type
+	Loc    *Loc
+}
+
+func (t *ListType) GetLoc() *Loc { return t.Loc }
+func (*ListType) isType()        {}
+
+// NonNullType is a T! type. Per spec, OfType must be a NamedType or ListType,
+// not another NonNullType — the parser enforces this.
+type NonNullType struct {
+	OfType Type
+	Loc    *Loc
+}
+
+func (t *NonNullType) GetLoc() *Loc { return t.Loc }
+func (*NonNullType) isType()        {}

--- a/ast/value.go
+++ b/ast/value.go
@@ -1,0 +1,108 @@
+package ast
+
+// IntValue is an integer literal. Value is the raw lexeme (e.g. "123",
+// "-1") so that callers can choose how to convert it (strconv.ParseInt,
+// math/big, etc.) — the spec leaves the integer range up to the consumer.
+type IntValue struct {
+	Value    string
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *IntValue) GetLoc() *Loc { return v.Loc }
+func (*IntValue) isValue()       {}
+
+// FloatValue is a floating-point literal. Value is the raw lexeme.
+type FloatValue struct {
+	Value    string
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *FloatValue) GetLoc() *Loc { return v.Loc }
+func (*FloatValue) isValue()       {}
+
+// StringValue is a string literal. Value is the post-decode value: escape
+// sequences are processed for "..." and the BlockStringValue dedent is
+// applied for """...""". The raw delimited bytes can be recovered via
+// Loc.Source.Body[Loc.Start:Loc.End].
+type StringValue struct {
+	Value    string
+	Block    bool // true if written as """..."""
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *StringValue) GetLoc() *Loc { return v.Loc }
+func (*StringValue) isValue()       {}
+
+// BooleanValue is one of the keywords true or false.
+type BooleanValue struct {
+	Value    bool
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *BooleanValue) GetLoc() *Loc { return v.Loc }
+func (*BooleanValue) isValue()       {}
+
+// NullValue is the null keyword.
+type NullValue struct {
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *NullValue) GetLoc() *Loc { return v.Loc }
+func (*NullValue) isValue()       {}
+
+// EnumValue is an enum literal — a Name that is not true, false, or null.
+type EnumValue struct {
+	Value    string
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *EnumValue) GetLoc() *Loc { return v.Loc }
+func (*EnumValue) isValue()       {}
+
+// ListValue is a [...] list literal.
+type ListValue struct {
+	Values   []Value
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *ListValue) GetLoc() *Loc { return v.Loc }
+func (*ListValue) isValue()       {}
+
+// ObjectValue is a {field: value, ...} object literal.
+type ObjectValue struct {
+	Fields   []*ObjectField
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *ObjectValue) GetLoc() *Loc { return v.Loc }
+func (*ObjectValue) isValue()       {}
+
+// ObjectField is one Name: Value entry inside an ObjectValue.
+type ObjectField struct {
+	Name     string
+	Value    Value
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (f *ObjectField) GetLoc() *Loc { return f.Loc }
+
+// Variable is a $name reference. It implements Value but the parser refuses
+// to produce one inside a const-value context (default values, directive
+// arguments on type definitions); see parser.ParseConstValue.
+type Variable struct {
+	Name     string
+	Loc      *Loc
+	Comments *CommentGroup
+}
+
+func (v *Variable) GetLoc() *Loc { return v.Loc }
+func (*Variable) isValue()       {}

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -1,0 +1,323 @@
+package ast
+
+// Visitor is the callback interface accepted by [Walk]. The Visit method is
+// called for each node in source order. Returning nil stops the traversal
+// from descending into the node's children; returning a non-nil Visitor
+// (typically the same value) continues with that visitor for the subtree.
+type Visitor interface {
+	Visit(node Node) Visitor
+}
+
+// Walk performs a depth-first, source-order traversal of node and its
+// children. It does not visit Comments or descend into BadValue/BadType/
+// BadField/BadDefinition placeholder nodes — they are leaves for traversal
+// purposes.
+func Walk(v Visitor, node Node) {
+	if node == nil {
+		return
+	}
+	v = v.Visit(node)
+	if v == nil {
+		return
+	}
+	switch n := node.(type) {
+	// Document and executable definitions
+	case *Document:
+		for _, def := range n.Definitions {
+			Walk(v, def)
+		}
+	case *OperationDefinition:
+		for _, vd := range n.VariableDefinitions {
+			Walk(v, vd)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		if n.SelectionSet != nil {
+			Walk(v, n.SelectionSet)
+		}
+	case *FragmentDefinition:
+		if n.TypeCondition != nil {
+			Walk(v, n.TypeCondition)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		if n.SelectionSet != nil {
+			Walk(v, n.SelectionSet)
+		}
+	case *VariableDefinition:
+		if n.Variable != nil {
+			Walk(v, n.Variable)
+		}
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		if n.DefaultValue != nil {
+			Walk(v, n.DefaultValue)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+	case *SelectionSet:
+		for _, s := range n.Selections {
+			Walk(v, s)
+		}
+	case *Field:
+		for _, a := range n.Arguments {
+			Walk(v, a)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		if n.SelectionSet != nil {
+			Walk(v, n.SelectionSet)
+		}
+	case *FragmentSpread:
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+	case *InlineFragment:
+		if n.TypeCondition != nil {
+			Walk(v, n.TypeCondition)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		if n.SelectionSet != nil {
+			Walk(v, n.SelectionSet)
+		}
+	case *Argument:
+		if n.Value != nil {
+			Walk(v, n.Value)
+		}
+	case *Directive:
+		for _, a := range n.Arguments {
+			Walk(v, a)
+		}
+
+	// Values
+	case *ListValue:
+		for _, val := range n.Values {
+			Walk(v, val)
+		}
+	case *ObjectValue:
+		for _, f := range n.Fields {
+			Walk(v, f)
+		}
+	case *ObjectField:
+		if n.Value != nil {
+			Walk(v, n.Value)
+		}
+
+	// Types
+	case *ListType:
+		if n.OfType != nil {
+			Walk(v, n.OfType)
+		}
+	case *NonNullType:
+		if n.OfType != nil {
+			Walk(v, n.OfType)
+		}
+
+	// Type-system definitions
+	case *SchemaDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, ot := range n.OperationTypes {
+			Walk(v, ot)
+		}
+	case *SchemaExtension:
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, ot := range n.OperationTypes {
+			Walk(v, ot)
+		}
+	case *OperationTypeDefinition:
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+
+	case *ScalarTypeDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+	case *ScalarTypeExtension:
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+
+	case *ObjectTypeDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, i := range n.Interfaces {
+			Walk(v, i)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, f := range n.Fields {
+			Walk(v, f)
+		}
+	case *ObjectTypeExtension:
+		for _, i := range n.Interfaces {
+			Walk(v, i)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, f := range n.Fields {
+			Walk(v, f)
+		}
+
+	case *InterfaceTypeDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, i := range n.Interfaces {
+			Walk(v, i)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, f := range n.Fields {
+			Walk(v, f)
+		}
+	case *InterfaceTypeExtension:
+		for _, i := range n.Interfaces {
+			Walk(v, i)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, f := range n.Fields {
+			Walk(v, f)
+		}
+
+	case *UnionTypeDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, m := range n.Members {
+			Walk(v, m)
+		}
+	case *UnionTypeExtension:
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, m := range n.Members {
+			Walk(v, m)
+		}
+
+	case *EnumTypeDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, ev := range n.Values {
+			Walk(v, ev)
+		}
+	case *EnumTypeExtension:
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, ev := range n.Values {
+			Walk(v, ev)
+		}
+
+	case *InputObjectTypeDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, f := range n.Fields {
+			Walk(v, f)
+		}
+	case *InputObjectTypeExtension:
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+		for _, f := range n.Fields {
+			Walk(v, f)
+		}
+
+	case *FieldDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, a := range n.Arguments {
+			Walk(v, a)
+		}
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+	case *InputValueDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		if n.DefaultValue != nil {
+			Walk(v, n.DefaultValue)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+	case *EnumValueDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, d := range n.Directives {
+			Walk(v, d)
+		}
+	case *DirectiveDefinition:
+		if n.Description != nil {
+			Walk(v, n.Description)
+		}
+		for _, a := range n.Arguments {
+			Walk(v, a)
+		}
+	}
+	// Falling through with no case match is a no-op: leaf nodes
+	// (IntValue, FloatValue, StringValue, BooleanValue, NullValue,
+	// EnumValue, Variable, NamedType, Comment, Bad*) have no children,
+	// so simply visiting them and returning is correct. Any future node
+	// kind added without a case here defaults to the same behavior.
+}
+
+// inspector adapts a func(Node) bool to the Visitor interface for Inspect.
+type inspector func(Node) bool
+
+func (f inspector) Visit(n Node) Visitor {
+	if f(n) {
+		return f
+	}
+	return nil
+}
+
+// Inspect walks node depth-first, calling fn for each visited node. If fn
+// returns false, descent into that node's children is skipped (sibling
+// traversal continues).
+func Inspect(node Node, fn func(Node) bool) {
+	Walk(inspector(fn), node)
+}

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -1,0 +1,223 @@
+package ast_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+// recordVisitor records every node it visits.
+type recordVisitor struct {
+	visited []ast.Node
+}
+
+func (r *recordVisitor) Visit(n ast.Node) ast.Visitor {
+	r.visited = append(r.visited, n)
+	return r
+}
+
+func TestWalk_NilNode(t *testing.T) {
+	r := &recordVisitor{}
+	ast.Walk(r, nil)
+	if len(r.visited) != 0 {
+		t.Errorf("expected no visits, got %d", len(r.visited))
+	}
+}
+
+func TestWalk_VisitsRoot(t *testing.T) {
+	doc, err := parser.Parse("{ x }")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &recordVisitor{}
+	ast.Walk(r, doc)
+	if len(r.visited) == 0 || r.visited[0] != ast.Node(doc) {
+		t.Errorf("first visit should be the root document; got %v", r.visited)
+	}
+}
+
+func TestWalk_StopOnNil(t *testing.T) {
+	doc, err := parser.Parse("{ x { y } }")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Visit the root, return nil → no descent.
+	stopped := &stoppingVisitor{}
+	ast.Walk(stopped, doc)
+	if stopped.count != 1 {
+		t.Errorf("expected 1 visit, got %d", stopped.count)
+	}
+}
+
+type stoppingVisitor struct{ count int }
+
+func (s *stoppingVisitor) Visit(ast.Node) ast.Visitor {
+	s.count++
+	return nil
+}
+
+func TestWalk_DescendsThroughExecutable(t *testing.T) {
+	body := `
+		query Q($v: Int = 1) @dir {
+			field(arg: 2) {
+				...frag
+				... on T @incl { y }
+			}
+		}
+		fragment frag on T { z }
+	`
+	doc, err := parser.Parse(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &recordVisitor{}
+	ast.Walk(r, doc)
+
+	expected := map[reflect.Type]bool{
+		reflect.TypeOf(&ast.Document{}):            true,
+		reflect.TypeOf(&ast.OperationDefinition{}): true,
+		reflect.TypeOf(&ast.VariableDefinition{}):  true,
+		reflect.TypeOf(&ast.Variable{}):            true,
+		reflect.TypeOf(&ast.NamedType{}):           true,
+		reflect.TypeOf(&ast.IntValue{}):            true,
+		reflect.TypeOf(&ast.Directive{}):           true,
+		reflect.TypeOf(&ast.SelectionSet{}):        true,
+		reflect.TypeOf(&ast.Field{}):               true,
+		reflect.TypeOf(&ast.Argument{}):            true,
+		reflect.TypeOf(&ast.FragmentSpread{}):      true,
+		reflect.TypeOf(&ast.InlineFragment{}):      true,
+		reflect.TypeOf(&ast.FragmentDefinition{}):  true,
+	}
+	for ty := range expected {
+		expected[ty] = false
+	}
+	for _, n := range r.visited {
+		expected[reflect.TypeOf(n)] = true
+	}
+	for ty, seen := range expected {
+		if !seen {
+			t.Errorf("walk did not visit a node of type %v", ty)
+		}
+	}
+}
+
+func TestWalk_DescendsThroughSchema(t *testing.T) {
+	body := `
+		"the schema" schema { query: Q }
+		"the type" type T implements I @x { f("arg desc" a: Int = 1 @arg): String }
+		interface I { id: ID }
+		union U = A | B
+		enum E { A B }
+		input In { f: Int }
+		directive @x repeatable on FIELD
+		extend type T { g: Int }
+	`
+	doc, err := parser.Parse(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &recordVisitor{}
+	ast.Walk(r, doc)
+
+	want := []reflect.Type{
+		reflect.TypeOf(&ast.SchemaDefinition{}),
+		reflect.TypeOf(&ast.OperationTypeDefinition{}),
+		reflect.TypeOf(&ast.ObjectTypeDefinition{}),
+		reflect.TypeOf(&ast.FieldDefinition{}),
+		reflect.TypeOf(&ast.InputValueDefinition{}),
+		reflect.TypeOf(&ast.InterfaceTypeDefinition{}),
+		reflect.TypeOf(&ast.UnionTypeDefinition{}),
+		reflect.TypeOf(&ast.EnumTypeDefinition{}),
+		reflect.TypeOf(&ast.EnumValueDefinition{}),
+		reflect.TypeOf(&ast.InputObjectTypeDefinition{}),
+		reflect.TypeOf(&ast.DirectiveDefinition{}),
+		reflect.TypeOf(&ast.ObjectTypeExtension{}),
+		reflect.TypeOf(&ast.StringValue{}), // descriptions
+	}
+	seen := map[reflect.Type]bool{}
+	for _, n := range r.visited {
+		seen[reflect.TypeOf(n)] = true
+	}
+	for _, ty := range want {
+		if !seen[ty] {
+			t.Errorf("walk did not visit a node of type %v", ty)
+		}
+	}
+}
+
+func TestInspect_StopOnFalse(t *testing.T) {
+	doc, err := parser.Parse("{ a { b { c } } }")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var depth int
+	ast.Inspect(doc, func(n ast.Node) bool {
+		if _, ok := n.(*ast.Field); ok {
+			depth++
+		}
+		// Stop at the first Field to prevent descent into nested ones.
+		if _, ok := n.(*ast.Field); ok {
+			return false
+		}
+		return true
+	})
+	if depth != 1 {
+		t.Errorf("expected to count exactly one Field; got %d", depth)
+	}
+}
+
+func TestWalk_DescendsThroughValues(t *testing.T) {
+	v, err := parser.ParseValue(`{a: [1, "hi", $v, ENUM, true, null], b: {nested: 1}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &recordVisitor{}
+	ast.Walk(r, v)
+
+	want := []reflect.Type{
+		reflect.TypeOf(&ast.ObjectValue{}),
+		reflect.TypeOf(&ast.ObjectField{}),
+		reflect.TypeOf(&ast.ListValue{}),
+		reflect.TypeOf(&ast.IntValue{}),
+		reflect.TypeOf(&ast.StringValue{}),
+		reflect.TypeOf(&ast.Variable{}),
+		reflect.TypeOf(&ast.EnumValue{}),
+		reflect.TypeOf(&ast.BooleanValue{}),
+		reflect.TypeOf(&ast.NullValue{}),
+	}
+	seen := map[reflect.Type]bool{}
+	for _, n := range r.visited {
+		seen[reflect.TypeOf(n)] = true
+	}
+	for _, ty := range want {
+		if !seen[ty] {
+			t.Errorf("walk did not visit a node of type %v", ty)
+		}
+	}
+}
+
+func TestWalk_DescendsThroughTypes(t *testing.T) {
+	t1, err := parser.ParseType("[Int!]!")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &recordVisitor{}
+	ast.Walk(r, t1)
+	// NonNull → List → NonNull → Named
+	want := []reflect.Type{
+		reflect.TypeOf(&ast.NonNullType{}),
+		reflect.TypeOf(&ast.ListType{}),
+		reflect.TypeOf(&ast.NamedType{}),
+	}
+	seen := map[reflect.Type]bool{}
+	for _, n := range r.visited {
+		seen[reflect.TypeOf(n)] = true
+	}
+	for _, ty := range want {
+		if !seen[ty] {
+			t.Errorf("did not visit %v", ty)
+		}
+	}
+}

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 // recordVisitor records every node it visits.

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -1,0 +1,57 @@
+# Performance discipline
+
+This library does not advertise a performance bar in its README. Benchmarks
+exist as a regression detector, not as a feature gate. Large regressions
+flagged by CI are surfaced on PRs but do not block merges. At v1.0, the
+README publishes absolute benchmark numbers (with machine spec); we do not
+publish comparisons to other libraries.
+
+What we *do* commit to is the implementation discipline below. These are
+the rules that keep the parser idiomatic, allocation-aware, and fast
+enough for the use cases the library targets without making perf a
+load-bearing feature of the project.
+
+## Rules
+
+1. **No `regexp`** in `lexer/` or `parser/`.
+   The grammar is small enough to hand-write. Regexp's setup cost on a
+   per-parse basis swamps the parsing itself for small inputs.
+
+2. **No `reflect`** in `lexer/`, `parser/`, or `ast/walk.go`.
+   The AST has ~40 concrete node types. Type switches are cheaper, easier
+   to read, and produce useful compile-time errors when a node kind is
+   missed.
+
+3. **No `fmt.Sprintf` on the hot path.**
+   Acceptable in error formatting (`ast/error.go` snippet rendering). Not
+   acceptable in `lexer/lexer.go`, `parser/parser.go`, or any function
+   called once per token / per node on a successful parse.
+
+4. **Tokens carry byte offsets**, not copied substrings.
+   `Token.Value` for `NAME`, `INT`, `FLOAT` is a sub-slice of
+   `Source.Body` (zero allocation). `STRING` and `COMMENT` tokens own
+   their decoded values because escape-decoding requires allocation
+   anyway.
+
+5. **`append`-grown lists**. No preallocation tricks unless a benchmark
+   proves they matter on a representative input. The Go runtime's slice
+   growth policy is good enough at the sizes GraphQL documents reach.
+
+6. **Memory linear in input size**. No hidden quadratic loops; no
+   unbounded-buffer accumulation.
+
+## Verification
+
+- `gofmt -l .` is empty.
+- `go vet ./...` is clean.
+- `grep -rn 'regexp\|reflect\|fmt.Sprintf' lexer/ parser/ ast/` returns
+  only allowed sites: `ast/error.go`, `ast/loc.go` (column formatting in
+  `Position.String`), and the comment-permitted error-message path in
+  `parser/parser.go`'s `describeToken`.
+- Benchmarks in `parser/benchmark_test.go` run cleanly on every PR with
+  `go test -bench=. -benchmem ./parser/`.
+
+## Reference numbers
+
+Captured at v1.0 on a known machine. Until then, treat
+`go test -bench=. ./parser/` as the source of truth on your hardware.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bellbm/graphql-parser
+
+go 1.26

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bellbm/graphql-parser
+module github.com/brian-bell/graphql-parser
 
 go 1.26

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -113,7 +113,7 @@ func (l *Lexer) lex() (Token, error) {
 			}
 			continue
 		case '"':
-			return Token{}, l.errAt(l.pos, "string literals are not yet supported in phase 2")
+			return l.lexString()
 		}
 		if c == '-' || isDigit(c) {
 			return l.lexNumber()

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"unicode/utf8"
 
-	"github.com/bellbm/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/ast"
 )
 
 // Lexer is a synchronous, single-token-lookahead tokenizer for a [ast.Source].

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,0 +1,313 @@
+package lexer
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/bellbm/graphql-parser/ast"
+)
+
+// Lexer is a synchronous, single-token-lookahead tokenizer for a [ast.Source].
+// It is not safe for concurrent use; callers should construct a fresh Lexer
+// per source.
+type Lexer struct {
+	source *ast.Source
+	body   string // == source.Body, cached for the hot loop
+	pos    int    // current byte offset into body
+
+	// PreserveComments controls whether COMMENT tokens reach the caller.
+	// When false (the default), the lexer skips comments silently as required
+	// by the GraphQL grammar (they are "ignored tokens"). When true, each
+	// comment is emitted as a COMMENT token whose Value is the text after
+	// '#' up to (but not including) the line terminator.
+	PreserveComments bool
+
+	peeked    bool
+	peekedTok Token
+	peekedErr error
+}
+
+// New constructs a Lexer for the given source. The source must outlive the
+// Lexer; tokens hold byte offsets into Source.Body.
+func New(src *ast.Source) *Lexer {
+	return &Lexer{source: src, body: src.Body}
+}
+
+// Source returns the underlying source.
+func (l *Lexer) Source() *ast.Source { return l.source }
+
+// Next consumes and returns the next token. At end of input it returns an
+// EOF token; subsequent calls continue to return EOF.
+func (l *Lexer) Next() (Token, error) {
+	if l.peeked {
+		tok, err := l.peekedTok, l.peekedErr
+		l.peeked = false
+		l.peekedTok = Token{}
+		l.peekedErr = nil
+		return tok, err
+	}
+	return l.lex()
+}
+
+// Peek returns the next token without consuming it. Repeated calls without
+// an intervening Next return the same token.
+func (l *Lexer) Peek() (Token, error) {
+	if l.peeked {
+		return l.peekedTok, l.peekedErr
+	}
+	tok, err := l.lex()
+	l.peeked = true
+	l.peekedTok = tok
+	l.peekedErr = err
+	return tok, err
+}
+
+func (l *Lexer) lex() (Token, error) {
+	for {
+		l.skipIgnored()
+		if l.pos >= len(l.body) {
+			return Token{Kind: EOF, Start: l.pos, End: l.pos}, nil
+		}
+		c := l.body[l.pos]
+		switch c {
+		case '!':
+			return l.singleByte(BANG), nil
+		case '$':
+			return l.singleByte(DOLLAR), nil
+		case '&':
+			return l.singleByte(AMP), nil
+		case '(':
+			return l.singleByte(LPAREN), nil
+		case ')':
+			return l.singleByte(RPAREN), nil
+		case ':':
+			return l.singleByte(COLON), nil
+		case '=':
+			return l.singleByte(EQUALS), nil
+		case '@':
+			return l.singleByte(AT), nil
+		case '[':
+			return l.singleByte(LBRACKET), nil
+		case ']':
+			return l.singleByte(RBRACKET), nil
+		case '{':
+			return l.singleByte(LBRACE), nil
+		case '|':
+			return l.singleByte(PIPE), nil
+		case '}':
+			return l.singleByte(RBRACE), nil
+		case '.':
+			if l.pos+2 < len(l.body) && l.body[l.pos+1] == '.' && l.body[l.pos+2] == '.' {
+				tok := Token{Kind: SPREAD, Start: l.pos, End: l.pos + 3}
+				l.pos += 3
+				return tok, nil
+			}
+			return Token{}, l.errAt(l.pos, fmt.Sprintf("Cannot parse the unexpected character %s.", quoteChar(c)))
+		case '#':
+			tok, ok, err := l.lexComment()
+			if err != nil {
+				return Token{}, err
+			}
+			if ok {
+				return tok, nil
+			}
+			continue
+		case '"':
+			return Token{}, l.errAt(l.pos, "string literals are not yet supported in phase 2")
+		}
+		if c == '-' || isDigit(c) {
+			return l.lexNumber()
+		}
+		if isNameStart(c) {
+			return l.lexName(), nil
+		}
+		return Token{}, l.errAt(l.pos, fmt.Sprintf("Cannot parse the unexpected character %s.", quoteChar(c)))
+	}
+}
+
+func (l *Lexer) singleByte(k Kind) Token {
+	tok := Token{Kind: k, Start: l.pos, End: l.pos + 1}
+	l.pos++
+	return tok
+}
+
+// skipIgnored advances past ignored tokens: BOM, whitespace, line terminators,
+// commas, and (when PreserveComments is false) comments. Comments are always
+// lexed for their byte range; this method just skips them when retention is off.
+func (l *Lexer) skipIgnored() {
+	for l.pos < len(l.body) {
+		c := l.body[l.pos]
+		switch c {
+		case ' ', '\t', ',', '\n', '\r':
+			l.pos++
+		case 0xEF:
+			// UTF-8 BOM: EF BB BF
+			if l.pos+2 < len(l.body) && l.body[l.pos+1] == 0xBB && l.body[l.pos+2] == 0xBF {
+				l.pos += 3
+				continue
+			}
+			return
+		case '#':
+			if l.PreserveComments {
+				return
+			}
+			// Skip to end of line; do not consume the terminator (the loop
+			// above will absorb it as whitespace).
+			for l.pos < len(l.body) && l.body[l.pos] != '\n' && l.body[l.pos] != '\r' {
+				l.pos++
+			}
+		default:
+			return
+		}
+	}
+}
+
+// lexComment reads a # comment, starting at the '#'. The returned token's
+// Value is the comment text (after '#', before the line terminator).
+// It returns ok=false if PreserveComments is false; in that case the caller
+// should resume looking for the next non-ignored token.
+func (l *Lexer) lexComment() (Token, bool, error) {
+	if !l.PreserveComments {
+		// skipIgnored should have absorbed it; defensive.
+		for l.pos < len(l.body) && l.body[l.pos] != '\n' && l.body[l.pos] != '\r' {
+			l.pos++
+		}
+		return Token{}, false, nil
+	}
+	start := l.pos
+	l.pos++ // consume '#'
+	textStart := l.pos
+	for l.pos < len(l.body) && l.body[l.pos] != '\n' && l.body[l.pos] != '\r' {
+		l.pos++
+	}
+	return Token{
+		Kind:  COMMENT,
+		Start: start,
+		End:   l.pos,
+		Value: l.body[textStart:l.pos],
+	}, true, nil
+}
+
+func (l *Lexer) lexName() Token {
+	start := l.pos
+	l.pos++ // first char already passed isNameStart
+	for l.pos < len(l.body) && isNameContinue(l.body[l.pos]) {
+		l.pos++
+	}
+	return Token{
+		Kind:  NAME,
+		Start: start,
+		End:   l.pos,
+		Value: l.body[start:l.pos],
+	}
+}
+
+func (l *Lexer) lexNumber() (Token, error) {
+	start := l.pos
+	if l.body[l.pos] == '-' {
+		l.pos++
+		if l.pos >= len(l.body) {
+			return Token{}, l.errAt(l.pos, "Invalid number, expected digit but got: <EOF>.")
+		}
+	}
+	c := l.body[l.pos]
+	if c == '0' {
+		l.pos++
+		// Reject leading-zero integers like "01", "012".
+		if l.pos < len(l.body) && isDigit(l.body[l.pos]) {
+			return Token{}, l.errAt(l.pos, fmt.Sprintf("Invalid number, unexpected digit after 0: %s.", quoteChar(l.body[l.pos])))
+		}
+	} else if isDigit(c) {
+		for l.pos < len(l.body) && isDigit(l.body[l.pos]) {
+			l.pos++
+		}
+	} else {
+		return Token{}, l.errAt(l.pos, fmt.Sprintf("Invalid number, expected digit but got: %s.", quoteChar(c)))
+	}
+
+	isFloat := false
+
+	if l.pos < len(l.body) && l.body[l.pos] == '.' {
+		isFloat = true
+		l.pos++
+		if l.pos >= len(l.body) || !isDigit(l.body[l.pos]) {
+			return Token{}, l.errAt(l.pos, fmt.Sprintf("Invalid number, expected digit but got: %s.", l.describeAt(l.pos)))
+		}
+		for l.pos < len(l.body) && isDigit(l.body[l.pos]) {
+			l.pos++
+		}
+	}
+
+	if l.pos < len(l.body) && (l.body[l.pos] == 'e' || l.body[l.pos] == 'E') {
+		isFloat = true
+		l.pos++
+		if l.pos < len(l.body) && (l.body[l.pos] == '+' || l.body[l.pos] == '-') {
+			l.pos++
+		}
+		if l.pos >= len(l.body) || !isDigit(l.body[l.pos]) {
+			return Token{}, l.errAt(l.pos, fmt.Sprintf("Invalid number, expected digit but got: %s.", l.describeAt(l.pos)))
+		}
+		for l.pos < len(l.body) && isDigit(l.body[l.pos]) {
+			l.pos++
+		}
+	}
+
+	// A number must not be immediately followed by a NameStart character or
+	// another '.', which would indicate a malformed token like "123abc" or
+	// "1.0.0".
+	if l.pos < len(l.body) {
+		c := l.body[l.pos]
+		if c == '.' || isNameStart(c) {
+			return Token{}, l.errAt(l.pos, fmt.Sprintf("Invalid number, expected digit but got: %s.", quoteChar(c)))
+		}
+	}
+
+	kind := INT
+	if isFloat {
+		kind = FLOAT
+	}
+	return Token{
+		Kind:  kind,
+		Start: start,
+		End:   l.pos,
+		Value: l.body[start:l.pos],
+	}, nil
+}
+
+// describeAt returns a quoted character at offset, or "<EOF>" if past the end.
+func (l *Lexer) describeAt(offset int) string {
+	if offset >= len(l.body) {
+		return "<EOF>"
+	}
+	return quoteChar(l.body[offset])
+}
+
+func (l *Lexer) errAt(offset int, msg string) *ast.SyntaxError {
+	return &ast.SyntaxError{Source: l.source, Offset: offset, Message: msg}
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func isNameStart(c byte) bool {
+	return c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
+func isNameContinue(c byte) bool {
+	return isNameStart(c) || isDigit(c)
+}
+
+// quoteChar formats a byte for inclusion in error messages, escaping
+// non-printables. It accepts a byte but renders it as a Unicode-escape if it
+// is the leading byte of a multi-byte sequence, since the lexer typically
+// errors on the first byte of an invalid character.
+func quoteChar(c byte) string {
+	if c >= utf8.RuneSelf {
+		return fmt.Sprintf("U+%04X", c)
+	}
+	if c < 0x20 || c == 0x7F {
+		return fmt.Sprintf("U+%04X", c)
+	}
+	return fmt.Sprintf("%q", string(c))
+}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -102,7 +102,7 @@ func (l *Lexer) lex() (Token, error) {
 				l.pos += 3
 				return tok, nil
 			}
-			return Token{}, l.errAt(l.pos, fmt.Sprintf("Cannot parse the unexpected character %s.", quoteChar(c)))
+			return Token{}, l.unexpectedCharErr()
 		case '#':
 			tok, ok, err := l.lexComment()
 			if err != nil {
@@ -121,8 +121,24 @@ func (l *Lexer) lex() (Token, error) {
 		if isNameStart(c) {
 			return l.lexName(), nil
 		}
-		return Token{}, l.errAt(l.pos, fmt.Sprintf("Cannot parse the unexpected character %s.", quoteChar(c)))
+		return Token{}, l.unexpectedCharErr()
 	}
+}
+
+// unexpectedCharErr builds an "unexpected character" error for the byte at
+// l.pos and advances l.pos past it (by one rune width, falling back to one
+// byte for invalid encodings). Advancing the position is what guarantees the
+// lexer makes progress on retry, which is what error recovery in the parser
+// needs to avoid an infinite loop on the same offending byte.
+func (l *Lexer) unexpectedCharErr() *ast.SyntaxError {
+	pos := l.pos
+	c := l.body[l.pos]
+	_, w := utf8.DecodeRuneInString(l.body[l.pos:])
+	if w < 1 {
+		w = 1
+	}
+	l.pos += w
+	return l.errAt(pos, fmt.Sprintf("Cannot parse the unexpected character %s.", quoteChar(c)))
 }
 
 func (l *Lexer) singleByte(k Kind) Token {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 func lex(t *testing.T, body string) *lexer.Lexer {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,0 +1,361 @@
+package lexer_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+func lex(t *testing.T, body string) *lexer.Lexer {
+	t.Helper()
+	return lexer.New(&ast.Source{Body: body, Name: "test.graphql"})
+}
+
+func mustNext(t *testing.T, l *lexer.Lexer) lexer.Token {
+	t.Helper()
+	tok, err := l.Next()
+	if err != nil {
+		t.Fatalf("Next: unexpected error: %v", err)
+	}
+	return tok
+}
+
+func TestLexer_Empty(t *testing.T) {
+	l := lex(t, "")
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.EOF {
+		t.Errorf("got %v; want EOF", tok.Kind)
+	}
+	if tok.Start != 0 || tok.End != 0 {
+		t.Errorf("EOF token has Start=%d End=%d; want 0,0", tok.Start, tok.End)
+	}
+	// Calling Next at EOF returns EOF again.
+	tok2 := mustNext(t, l)
+	if tok2.Kind != lexer.EOF {
+		t.Errorf("second call: got %v; want EOF", tok2.Kind)
+	}
+}
+
+func TestLexer_Punctuators(t *testing.T) {
+	cases := []struct {
+		body string
+		kind lexer.Kind
+	}{
+		{"!", lexer.BANG},
+		{"$", lexer.DOLLAR},
+		{"&", lexer.AMP},
+		{"(", lexer.LPAREN},
+		{")", lexer.RPAREN},
+		{"...", lexer.SPREAD},
+		{":", lexer.COLON},
+		{"=", lexer.EQUALS},
+		{"@", lexer.AT},
+		{"[", lexer.LBRACKET},
+		{"]", lexer.RBRACKET},
+		{"{", lexer.LBRACE},
+		{"|", lexer.PIPE},
+		{"}", lexer.RBRACE},
+	}
+	for _, c := range cases {
+		t.Run(c.body, func(t *testing.T) {
+			l := lex(t, c.body)
+			tok := mustNext(t, l)
+			if tok.Kind != c.kind {
+				t.Errorf("%q: kind = %v; want %v", c.body, tok.Kind, c.kind)
+			}
+			if tok.Start != 0 || tok.End != len(c.body) {
+				t.Errorf("%q: range = [%d, %d); want [0, %d)", c.body, tok.Start, tok.End, len(c.body))
+			}
+			if eof := mustNext(t, l); eof.Kind != lexer.EOF {
+				t.Errorf("after %q: got %v; want EOF", c.body, eof.Kind)
+			}
+		})
+	}
+}
+
+func TestLexer_SpreadInsufficientDots(t *testing.T) {
+	for _, body := range []string{".", ".."} {
+		l := lex(t, body)
+		if _, err := l.Next(); err == nil {
+			t.Errorf("%q: expected error", body)
+		}
+	}
+}
+
+func TestLexer_Name(t *testing.T) {
+	cases := []string{"a", "abc", "_under", "_", "A1", "X9_Y", "query"}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			l := lex(t, body)
+			tok := mustNext(t, l)
+			if tok.Kind != lexer.NAME {
+				t.Errorf("kind = %v; want NAME", tok.Kind)
+			}
+			if tok.Value != body {
+				t.Errorf("Value = %q; want %q", tok.Value, body)
+			}
+			if tok.Start != 0 || tok.End != len(body) {
+				t.Errorf("range = [%d, %d); want [0, %d)", tok.Start, tok.End, len(body))
+			}
+		})
+	}
+}
+
+func TestLexer_NameNotStartingWithDigit(t *testing.T) {
+	// "1abc" should lex as INT 1, then error at NAME continuation, since the
+	// number cannot be immediately followed by a NameStart character.
+	l := lex(t, "1abc")
+	if _, err := l.Next(); err == nil {
+		t.Error("expected error for '1abc'")
+	}
+}
+
+func TestLexer_Int(t *testing.T) {
+	cases := []string{"0", "1", "12", "123", "9876543210", "-0", "-1", "-12"}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			l := lex(t, body)
+			tok := mustNext(t, l)
+			if tok.Kind != lexer.INT {
+				t.Errorf("kind = %v; want INT", tok.Kind)
+			}
+			if tok.Value != body {
+				t.Errorf("Value = %q; want %q", tok.Value, body)
+			}
+		})
+	}
+}
+
+func TestLexer_IntInvalid(t *testing.T) {
+	cases := []string{"00", "01", "-01", "0123", "+1", "-", "- 1"}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			l := lex(t, body)
+			if _, err := l.Next(); err == nil {
+				t.Errorf("%q: expected error", body)
+			}
+		})
+	}
+}
+
+func TestLexer_Float(t *testing.T) {
+	cases := []string{
+		"0.0", "1.0", "1.23", "-1.0", "0.123",
+		"1e0", "1E0", "1e+5", "1e-5", "1.0e2",
+		"-1.0e-2", "123.456e789",
+	}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			l := lex(t, body)
+			tok := mustNext(t, l)
+			if tok.Kind != lexer.FLOAT {
+				t.Errorf("kind = %v; want FLOAT (body %q)", tok.Kind, body)
+			}
+			if tok.Value != body {
+				t.Errorf("Value = %q; want %q", tok.Value, body)
+			}
+		})
+	}
+}
+
+func TestLexer_FloatInvalid(t *testing.T) {
+	cases := []string{
+		"1.", "1.e1", "1.0.0", "1e", "1e+", "1ea",
+		".0", "-.0",
+	}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			l := lex(t, body)
+			if _, err := l.Next(); err == nil {
+				t.Errorf("%q: expected error", body)
+			}
+		})
+	}
+}
+
+func TestLexer_NumberFollowedBy(t *testing.T) {
+	// A number followed by punctuation or whitespace is fine.
+	l := lex(t, "1 2.0,3")
+	expect := []struct {
+		kind  lexer.Kind
+		value string
+	}{
+		{lexer.INT, "1"},
+		{lexer.FLOAT, "2.0"},
+		{lexer.INT, "3"},
+		{lexer.EOF, ""},
+	}
+	for i, want := range expect {
+		tok := mustNext(t, l)
+		if tok.Kind != want.kind || tok.Value != want.value {
+			t.Errorf("token %d: got %v %q; want %v %q", i, tok.Kind, tok.Value, want.kind, want.value)
+		}
+	}
+}
+
+func TestLexer_IgnoreWhitespace(t *testing.T) {
+	l := lex(t, "  \t\n\r\n  foo  ")
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.NAME || tok.Value != "foo" {
+		t.Errorf("got %v %q; want NAME foo", tok.Kind, tok.Value)
+	}
+	if eof := mustNext(t, l); eof.Kind != lexer.EOF {
+		t.Errorf("got %v; want EOF", eof.Kind)
+	}
+}
+
+func TestLexer_IgnoreCommas(t *testing.T) {
+	l := lex(t, "a,b,,,c")
+	for _, want := range []string{"a", "b", "c"} {
+		tok := mustNext(t, l)
+		if tok.Kind != lexer.NAME || tok.Value != want {
+			t.Errorf("got %v %q; want NAME %q", tok.Kind, tok.Value, want)
+		}
+	}
+	if eof := mustNext(t, l); eof.Kind != lexer.EOF {
+		t.Errorf("got %v; want EOF", eof.Kind)
+	}
+}
+
+func TestLexer_IgnoreBOM(t *testing.T) {
+	l := lex(t, "\ufefffoo")
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.NAME || tok.Value != "foo" {
+		t.Errorf("got %v %q; want NAME foo", tok.Kind, tok.Value)
+	}
+}
+
+func TestLexer_CommentSkippedByDefault(t *testing.T) {
+	l := lex(t, "# leading comment\nfoo # trailing\n# another\nbar")
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.NAME || tok.Value != "foo" {
+		t.Errorf("got %v %q; want NAME foo", tok.Kind, tok.Value)
+	}
+	tok = mustNext(t, l)
+	if tok.Kind != lexer.NAME || tok.Value != "bar" {
+		t.Errorf("got %v %q; want NAME bar", tok.Kind, tok.Value)
+	}
+}
+
+func TestLexer_CommentRetained(t *testing.T) {
+	l := lex(t, "# hello\nfoo")
+	l.PreserveComments = true
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.COMMENT {
+		t.Fatalf("got %v; want COMMENT", tok.Kind)
+	}
+	if tok.Value != " hello" {
+		t.Errorf("comment Value = %q; want %q", tok.Value, " hello")
+	}
+	tok = mustNext(t, l)
+	if tok.Kind != lexer.NAME || tok.Value != "foo" {
+		t.Errorf("got %v %q; want NAME foo", tok.Kind, tok.Value)
+	}
+}
+
+func TestLexer_CommentToEOF(t *testing.T) {
+	// Comment with no trailing newline is fine.
+	l := lex(t, "foo # final comment, no newline")
+	if tok := mustNext(t, l); tok.Kind != lexer.NAME {
+		t.Errorf("got %v; want NAME", tok.Kind)
+	}
+	if eof := mustNext(t, l); eof.Kind != lexer.EOF {
+		t.Errorf("got %v; want EOF", eof.Kind)
+	}
+}
+
+func TestLexer_Peek(t *testing.T) {
+	l := lex(t, "foo bar")
+	tok1, err := l.Peek()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok1.Value != "foo" {
+		t.Errorf("Peek 1 = %q; want foo", tok1.Value)
+	}
+	// Peek twice — same result, no advance.
+	tok1b, _ := l.Peek()
+	if tok1b.Start != tok1.Start || tok1b.End != tok1.End {
+		t.Errorf("Peek twice differs: %+v vs %+v", tok1, tok1b)
+	}
+	// Next returns the peeked token.
+	got := mustNext(t, l)
+	if got.Value != "foo" {
+		t.Errorf("Next after Peek = %q; want foo", got.Value)
+	}
+	// Then bar.
+	got = mustNext(t, l)
+	if got.Value != "bar" {
+		t.Errorf("Next = %q; want bar", got.Value)
+	}
+}
+
+func TestLexer_PositionsAreByteOffsets(t *testing.T) {
+	l := lex(t, "  foo\n  bar")
+	tok := mustNext(t, l)
+	if tok.Start != 2 || tok.End != 5 {
+		t.Errorf("foo range = [%d, %d); want [2, 5)", tok.Start, tok.End)
+	}
+	tok = mustNext(t, l)
+	if tok.Start != 8 || tok.End != 11 {
+		t.Errorf("bar range = [%d, %d); want [8, 11)", tok.Start, tok.End)
+	}
+}
+
+func TestLexer_UnexpectedCharacter(t *testing.T) {
+	cases := []string{"?", "*", "%", "^", ";"}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			l := lex(t, body)
+			_, err := l.Next()
+			if err == nil {
+				t.Errorf("%q: expected error", body)
+			}
+			var se *ast.SyntaxError
+			if !errAs(err, &se) {
+				t.Errorf("%q: expected *ast.SyntaxError, got %T", body, err)
+			}
+		})
+	}
+}
+
+func TestLexer_ErrorPosition(t *testing.T) {
+	l := lex(t, "foo\n  ?")
+	if _, err := l.Next(); err != nil {
+		t.Fatalf("first Next: %v", err)
+	}
+	_, err := l.Next()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var se *ast.SyntaxError
+	if !errAs(err, &se) {
+		t.Fatalf("expected *ast.SyntaxError, got %T", err)
+	}
+	if pos := se.Position(); pos != (ast.Position{Line: 2, Column: 3}) {
+		t.Errorf("error position = %+v; want {2, 3}", pos)
+	}
+	// Subsequent message should reflect the offending character.
+	if !strings.Contains(se.Message, "?") {
+		t.Errorf("error message %q does not mention '?'", se.Message)
+	}
+}
+
+// errAs is a tiny errors.As shim to keep the test file dependency-free.
+func errAs(err error, target **ast.SyntaxError) bool {
+	for err != nil {
+		if se, ok := err.(*ast.SyntaxError); ok {
+			*target = se
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/lexer/string.go
+++ b/lexer/string.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"unicode/utf8"
 
-	"github.com/bellbm/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/ast"
 )
 
 // lexString reads a string token starting at l.pos (which must point at '"').

--- a/lexer/string.go
+++ b/lexer/string.go
@@ -1,0 +1,247 @@
+package lexer
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/bellbm/graphql-parser/ast"
+)
+
+// lexString reads a string token starting at l.pos (which must point at '"').
+// It dispatches to lexBlockString for """...""" syntax.
+func (l *Lexer) lexString() (Token, error) {
+	if l.pos+2 < len(l.body) && l.body[l.pos+1] == '"' && l.body[l.pos+2] == '"' {
+		return l.lexBlockString()
+	}
+	return l.lexSimpleString()
+}
+
+func (l *Lexer) lexSimpleString() (Token, error) {
+	start := l.pos
+	l.pos++ // consume opening "
+
+	var buf []byte
+	runStart := l.pos
+
+	for l.pos < len(l.body) {
+		c := l.body[l.pos]
+		switch {
+		case c == '"':
+			value := l.body[runStart:l.pos]
+			if buf != nil {
+				buf = append(buf, value...)
+				value = string(buf)
+			}
+			l.pos++
+			return Token{Kind: STRING, Start: start, End: l.pos, Value: value}, nil
+
+		case c == '\\':
+			if buf == nil {
+				buf = make([]byte, 0, l.pos-start)
+			}
+			buf = append(buf, l.body[runStart:l.pos]...)
+			l.pos++ // consume backslash
+			if err := l.decodeEscape(&buf); err != nil {
+				return Token{}, err
+			}
+			runStart = l.pos
+
+		case c == '\n' || c == '\r':
+			return Token{}, l.errAt(l.pos, "Unterminated string.")
+
+		case c < 0x20 && c != '\t':
+			return Token{}, l.errAt(l.pos, fmt.Sprintf("Invalid character within String: %s.", quoteChar(c)))
+
+		default:
+			l.pos++
+		}
+	}
+	return Token{}, l.errAt(l.pos, "Unterminated string.")
+}
+
+// decodeEscape consumes a backslash-escape (the backslash itself has already
+// been consumed by the caller) and appends the decoded bytes to dst.
+func (l *Lexer) decodeEscape(dst *[]byte) error {
+	if l.pos >= len(l.body) {
+		return l.errAt(l.pos, "Unterminated string.")
+	}
+	c := l.body[l.pos]
+	switch c {
+	case '"':
+		l.pos++
+		*dst = append(*dst, '"')
+	case '\\':
+		l.pos++
+		*dst = append(*dst, '\\')
+	case '/':
+		l.pos++
+		*dst = append(*dst, '/')
+	case 'b':
+		l.pos++
+		*dst = append(*dst, '\b')
+	case 'f':
+		l.pos++
+		*dst = append(*dst, '\f')
+	case 'n':
+		l.pos++
+		*dst = append(*dst, '\n')
+	case 'r':
+		l.pos++
+		*dst = append(*dst, '\r')
+	case 't':
+		l.pos++
+		*dst = append(*dst, '\t')
+	case 'u':
+		l.pos++
+		return l.decodeUnicodeEscape(dst)
+	default:
+		// Caller has already consumed the backslash; report the error at it.
+		return l.errAt(l.pos-1, fmt.Sprintf("Invalid character escape sequence: \"\\%s\".", string(c)))
+	}
+	return nil
+}
+
+func (l *Lexer) decodeUnicodeEscape(dst *[]byte) error {
+	if l.pos < len(l.body) && l.body[l.pos] == '{' {
+		return l.decodeVariableUnicodeEscape(dst)
+	}
+	return l.decodeFixedUnicodeEscape(dst)
+}
+
+func (l *Lexer) decodeFixedUnicodeEscape(dst *[]byte) error {
+	// l.pos is just past 'u'. Need exactly 4 hex digits.
+	escapeStart := l.pos - 2 // points at '\\'
+	if l.pos+4 > len(l.body) {
+		return l.errAt(escapeStart, "Invalid Unicode escape sequence: too short.")
+	}
+	cp, ok := parseHex(l.body[l.pos : l.pos+4])
+	if !ok {
+		return l.errAt(escapeStart, fmt.Sprintf("Invalid Unicode escape sequence: \"\\u%s\".", l.body[l.pos:l.pos+4]))
+	}
+	l.pos += 4
+
+	// Handle a high surrogate followed by a fixed low-surrogate escape.
+	if cp >= 0xD800 && cp <= 0xDBFF {
+		if l.pos+6 <= len(l.body) &&
+			l.body[l.pos] == '\\' && l.body[l.pos+1] == 'u' && l.body[l.pos+2] != '{' {
+			lo, ok2 := parseHex(l.body[l.pos+2 : l.pos+6])
+			if ok2 && lo >= 0xDC00 && lo <= 0xDFFF {
+				cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00)
+				l.pos += 6
+				return appendRune(dst, rune(cp))
+			}
+		}
+		return l.errAt(escapeStart, "Invalid Unicode escape sequence: lone high surrogate.")
+	}
+	if cp >= 0xDC00 && cp <= 0xDFFF {
+		return l.errAt(escapeStart, "Invalid Unicode escape sequence: lone low surrogate.")
+	}
+	return appendRune(dst, rune(cp))
+}
+
+func (l *Lexer) decodeVariableUnicodeEscape(dst *[]byte) error {
+	escapeStart := l.pos - 2 // points at '\\'
+	l.pos++                  // consume '{'
+	hexStart := l.pos
+	for l.pos < len(l.body) && l.body[l.pos] != '}' {
+		l.pos++
+	}
+	if l.pos >= len(l.body) {
+		return l.errAt(escapeStart, "Invalid Unicode escape sequence: unterminated.")
+	}
+	hex := l.body[hexStart:l.pos]
+	l.pos++ // consume '}'
+	if len(hex) == 0 || len(hex) > 6 {
+		return l.errAt(escapeStart, fmt.Sprintf("Invalid Unicode escape sequence: \"\\u{%s}\".", hex))
+	}
+	cp, ok := parseHex(hex)
+	if !ok || cp > 0x10FFFF {
+		return l.errAt(escapeStart, fmt.Sprintf("Invalid Unicode escape sequence: \"\\u{%s}\".", hex))
+	}
+	if cp >= 0xD800 && cp <= 0xDFFF {
+		return l.errAt(escapeStart, fmt.Sprintf("Invalid Unicode escape sequence: \"\\u{%s}\" (surrogate).", hex))
+	}
+	return appendRune(dst, rune(cp))
+}
+
+// parseHex parses up to 6 hex digits as a uint32. Returns false if any byte
+// is not a hex digit.
+func parseHex(s string) (uint32, bool) {
+	var v uint32
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		var d uint32
+		switch {
+		case c >= '0' && c <= '9':
+			d = uint32(c - '0')
+		case c >= 'a' && c <= 'f':
+			d = uint32(c-'a') + 10
+		case c >= 'A' && c <= 'F':
+			d = uint32(c-'A') + 10
+		default:
+			return 0, false
+		}
+		v = v<<4 | d
+	}
+	return v, true
+}
+
+func appendRune(dst *[]byte, r rune) error {
+	if !utf8.ValidRune(r) {
+		return fmt.Errorf("invalid rune U+%04X after escape decoding", r)
+	}
+	var buf [4]byte
+	n := utf8.EncodeRune(buf[:], r)
+	*dst = append(*dst, buf[:n]...)
+	return nil
+}
+
+// lexBlockString reads a """...""" string. The only escape inside a block
+// string is \""" (which becomes literal """); all other characters are taken
+// literally, including line terminators and backslashes.
+func (l *Lexer) lexBlockString() (Token, error) {
+	start := l.pos
+	l.pos += 3 // consume opening """
+
+	var buf []byte
+	runStart := l.pos
+
+	for l.pos < len(l.body) {
+		// End of block string: """
+		if l.body[l.pos] == '"' &&
+			l.pos+2 < len(l.body) &&
+			l.body[l.pos+1] == '"' &&
+			l.body[l.pos+2] == '"' {
+			raw := l.body[runStart:l.pos]
+			if buf != nil {
+				buf = append(buf, raw...)
+				raw = string(buf)
+			}
+			l.pos += 3
+			return Token{
+				Kind:  STRING,
+				Block: true,
+				Start: start,
+				End:   l.pos,
+				Value: ast.BlockStringValue(raw),
+			}, nil
+		}
+		// Escaped triple quote: \""" → """
+		if l.body[l.pos] == '\\' &&
+			l.pos+3 < len(l.body) &&
+			l.body[l.pos+1] == '"' &&
+			l.body[l.pos+2] == '"' &&
+			l.body[l.pos+3] == '"' {
+			if buf == nil {
+				buf = make([]byte, 0, l.pos-start)
+			}
+			buf = append(buf, l.body[runStart:l.pos]...)
+			buf = append(buf, '"', '"', '"')
+			l.pos += 4
+			runStart = l.pos
+			continue
+		}
+		l.pos++
+	}
+	return Token{}, l.errAt(l.pos, "Unterminated block string.")
+}

--- a/lexer/string_test.go
+++ b/lexer/string_test.go
@@ -1,0 +1,260 @@
+package lexer_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+func TestLexer_String_Empty(t *testing.T) {
+	l := lex(t, `""`)
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.STRING {
+		t.Fatalf("kind = %v; want STRING", tok.Kind)
+	}
+	if tok.Value != "" {
+		t.Errorf("Value = %q; want empty", tok.Value)
+	}
+	if tok.Block {
+		t.Error("Block = true; want false")
+	}
+}
+
+func TestLexer_String_Simple(t *testing.T) {
+	l := lex(t, `"hello, world"`)
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.STRING {
+		t.Fatalf("kind = %v; want STRING", tok.Kind)
+	}
+	if tok.Value != "hello, world" {
+		t.Errorf("Value = %q; want %q", tok.Value, "hello, world")
+	}
+	if tok.Start != 0 || tok.End != 14 {
+		t.Errorf("range = [%d, %d); want [0, 14)", tok.Start, tok.End)
+	}
+}
+
+func TestLexer_String_Escapes(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`"\""`, `"`},
+		{`"\\"`, `\`},
+		{`"\/"`, `/`},
+		{`"\b"`, "\b"},
+		{`"\f"`, "\f"},
+		{`"\n"`, "\n"},
+		{`"\r"`, "\r"},
+		{`"\t"`, "\t"},
+		{`"\"escaped\""`, `"escaped"`},
+		{`"a\tb\nc"`, "a\tb\nc"},
+	}
+	for _, c := range cases {
+		t.Run(c.body, func(t *testing.T) {
+			l := lex(t, c.body)
+			tok := mustNext(t, l)
+			if tok.Kind != lexer.STRING {
+				t.Fatalf("kind = %v; want STRING", tok.Kind)
+			}
+			if tok.Value != c.want {
+				t.Errorf("Value = %q; want %q", tok.Value, c.want)
+			}
+		})
+	}
+}
+
+func TestLexer_String_UnicodeFixed(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`"é"`, "é"},
+		{`"A"`, "A"},
+		{`"épique"`, "épique"},
+		// Surrogate pair: 😀 = U+1F600 = high D83D, low DE00.
+		{`"😀"`, "\U0001F600"},
+	}
+	for _, c := range cases {
+		t.Run(c.body, func(t *testing.T) {
+			l := lex(t, c.body)
+			tok := mustNext(t, l)
+			if tok.Kind != lexer.STRING {
+				t.Fatalf("kind = %v; want STRING", tok.Kind)
+			}
+			if tok.Value != c.want {
+				t.Errorf("Value = %q (% x); want %q (% x)", tok.Value, tok.Value, c.want, c.want)
+			}
+		})
+	}
+}
+
+func TestLexer_String_UnicodeVariable(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`"\u{0041}"`, "A"},
+		{`"\u{1F600}"`, "\U0001F600"},
+		{`"\u{0}"`, "\x00"},
+		{`"\u{10FFFF}"`, "\U0010FFFF"},
+	}
+	for _, c := range cases {
+		t.Run(c.body, func(t *testing.T) {
+			l := lex(t, c.body)
+			tok := mustNext(t, l)
+			if tok.Kind != lexer.STRING {
+				t.Fatalf("kind = %v; want STRING", tok.Kind)
+			}
+			if tok.Value != c.want {
+				t.Errorf("Value = %q (% x); want %q (% x)", tok.Value, tok.Value, c.want, c.want)
+			}
+		})
+	}
+}
+
+func TestLexer_String_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"unterminated", `"abc`},
+		{"unterminated empty", `"`},
+		{"newline in string", "\"abc\ndef\""},
+		{"CR in string", "\"abc\rdef\""},
+		{"control character", "\"abc\x01def\""},
+		{"invalid escape", `"\x"`},
+		{"bad fixed unicode hex", `"\u00G0"`},
+		{"truncated fixed unicode", `"\u12"`},
+		{"lone high surrogate", `"\uD83D"`},
+		{"lone low surrogate", `"\uDE00"`},
+		{"high surrogate with non-low after", `"\uD83DA"`},
+		{"variable unicode empty", `"\u{}"`},
+		{"variable unicode too long", `"\u{1234567}"`},
+		{"variable unicode out of range", `"\u{110000}"`},
+		{"variable unicode surrogate", `"\u{D800}"`},
+		{"variable unicode unterminated", `"\u{1F600`},
+		{"variable unicode bad hex", `"\u{ZZ}"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			l := lex(t, c.body)
+			if _, err := l.Next(); err == nil {
+				t.Errorf("body %q: expected error", c.body)
+			}
+		})
+	}
+}
+
+func TestLexer_String_TabAllowedInString(t *testing.T) {
+	// Tab is allowed; only the other control characters (< 0x20 except \t) are
+	// rejected mid-string per spec.
+	l := lex(t, "\"a\tb\"")
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.STRING {
+		t.Fatalf("kind = %v; want STRING", tok.Kind)
+	}
+	if tok.Value != "a\tb" {
+		t.Errorf("Value = %q; want %q", tok.Value, "a\tb")
+	}
+}
+
+func TestLexer_BlockString_Empty(t *testing.T) {
+	l := lex(t, `""""""`)
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.STRING {
+		t.Fatalf("kind = %v; want STRING", tok.Kind)
+	}
+	if !tok.Block {
+		t.Error("Block = false; want true")
+	}
+	if tok.Value != "" {
+		t.Errorf("Value = %q; want empty", tok.Value)
+	}
+}
+
+func TestLexer_BlockString_Simple(t *testing.T) {
+	l := lex(t, `"""hello"""`)
+	tok := mustNext(t, l)
+	if !tok.Block {
+		t.Error("Block = false; want true")
+	}
+	if tok.Value != "hello" {
+		t.Errorf("Value = %q; want %q", tok.Value, "hello")
+	}
+}
+
+func TestLexer_BlockString_Dedent(t *testing.T) {
+	body := "\"\"\"\n    Hello,\n      World!\n\"\"\""
+	l := lex(t, body)
+	tok := mustNext(t, l)
+	if !tok.Block {
+		t.Error("Block = false; want true")
+	}
+	if tok.Value != "Hello,\n  World!" {
+		t.Errorf("Value = %q; want %q", tok.Value, "Hello,\n  World!")
+	}
+}
+
+func TestLexer_BlockString_EscapedTripleQuote(t *testing.T) {
+	body := `"""contains \""" inside"""`
+	l := lex(t, body)
+	tok := mustNext(t, l)
+	if tok.Value != `contains """ inside` {
+		t.Errorf("Value = %q; want %q", tok.Value, `contains """ inside`)
+	}
+}
+
+func TestLexer_BlockString_NoOtherEscapes(t *testing.T) {
+	// Inside a block string, only \""" is special. \n is the literal two
+	// characters, not a newline.
+	body := `"""\n"""`
+	l := lex(t, body)
+	tok := mustNext(t, l)
+	if tok.Value != `\n` {
+		t.Errorf("Value = %q; want %q (literal backslash-n)", tok.Value, `\n`)
+	}
+}
+
+func TestLexer_BlockString_Unterminated(t *testing.T) {
+	body := `"""hello`
+	l := lex(t, body)
+	if _, err := l.Next(); err == nil {
+		t.Error("expected unterminated block string error")
+	}
+}
+
+func TestLexer_BlockString_PositionsCoverDelimiters(t *testing.T) {
+	body := `"""hi"""`
+	l := lex(t, body)
+	tok := mustNext(t, l)
+	if tok.Start != 0 || tok.End != len(body) {
+		t.Errorf("range = [%d, %d); want [0, %d)", tok.Start, tok.End, len(body))
+	}
+}
+
+func TestLexer_String_PositionsCoverQuotes(t *testing.T) {
+	body := `"hi"`
+	l := lex(t, body)
+	tok := mustNext(t, l)
+	if tok.Start != 0 || tok.End != 4 {
+		t.Errorf("range = [%d, %d); want [0, 4)", tok.Start, tok.End)
+	}
+}
+
+func TestLexer_String_ErrorMessageMentionsString(t *testing.T) {
+	l := lex(t, `"\x"`)
+	_, err := l.Next()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var se *ast.SyntaxError
+	if !errAs(err, &se) {
+		t.Fatalf("expected *ast.SyntaxError, got %T", err)
+	}
+	if !strings.Contains(strings.ToLower(se.Message), "escape") {
+		t.Errorf("message %q does not mention escape", se.Message)
+	}
+}

--- a/lexer/string_test.go
+++ b/lexer/string_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 func TestLexer_String_Empty(t *testing.T) {

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -1,0 +1,87 @@
+// Package lexer tokenizes a GraphQL source document.
+//
+// Tokens hold byte offsets into the source rather than copied strings; for
+// NAME, INT, and FLOAT tokens the Value field is a sub-slice of the source
+// body (zero allocation). STRING tokens own their decoded value.
+package lexer
+
+// Kind identifies a token's lexical category. The zero value is reserved for
+// "uninitialized" so that an empty Token can be distinguished from a real one.
+type Kind uint8
+
+const (
+	invalid Kind = iota
+	EOF
+	BANG     // !
+	DOLLAR   // $
+	AMP      // &
+	LPAREN   // (
+	RPAREN   // )
+	SPREAD   // ...
+	COLON    // :
+	EQUALS   // =
+	AT       // @
+	LBRACKET // [
+	RBRACKET // ]
+	LBRACE   // {
+	PIPE     // |
+	RBRACE   // }
+	NAME
+	INT
+	FLOAT
+	STRING
+	COMMENT
+)
+
+var kindNames = [...]string{
+	invalid:  "<invalid>",
+	EOF:      "<EOF>",
+	BANG:     "!",
+	DOLLAR:   "$",
+	AMP:      "&",
+	LPAREN:   "(",
+	RPAREN:   ")",
+	SPREAD:   "...",
+	COLON:    ":",
+	EQUALS:   "=",
+	AT:       "@",
+	LBRACKET: "[",
+	RBRACKET: "]",
+	LBRACE:   "{",
+	PIPE:     "|",
+	RBRACE:   "}",
+	NAME:     "Name",
+	INT:      "Int",
+	FLOAT:    "Float",
+	STRING:   "String",
+	COMMENT:  "Comment",
+}
+
+// String returns a human-readable name for the token kind, suitable for use
+// in error messages.
+func (k Kind) String() string {
+	if int(k) < len(kindNames) {
+		return kindNames[k]
+	}
+	return "<unknown>"
+}
+
+// Token is a single lexical unit.
+//
+// Start and End are byte offsets into the source body; End is exclusive
+// (half-open [Start, End)).
+//
+// Value is populated for NAME, INT, FLOAT, STRING, and COMMENT tokens.
+// For NAME/INT/FLOAT it is a sub-slice of the source body.
+// For STRING it is the escape-decoded (or block-string-dedented) value.
+// For COMMENT it is the comment text (everything after the '#', up to but
+// not including the line terminator).
+//
+// Block is set on STRING tokens that were written using the """...""" syntax.
+type Token struct {
+	Kind  Kind
+	Start int
+	End   int
+	Value string
+	Block bool
+}

--- a/parser/api.go
+++ b/parser/api.go
@@ -2,6 +2,26 @@ package parser
 
 import "github.com/bellbm/graphql-parser/ast"
 
+// Parse parses a GraphQL source document and returns its [ast.Document].
+// The source is wrapped in an ast.Source named "GraphQL" for error messages;
+// use [ParseSource] to supply your own filename and location offset.
+func Parse(body string, opts ...Option) (*ast.Document, error) {
+	return ParseSource(&ast.Source{Body: body, Name: "GraphQL"}, opts...)
+}
+
+// ParseSource parses a GraphQL document from src.
+func ParseSource(src *ast.Source, opts ...Option) (*ast.Document, error) {
+	p := newParser(src, opts)
+	doc, err := p.parseDocument()
+	if err != nil {
+		return nil, err
+	}
+	if err := p.expectEOF(); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
 // ParseValue parses a single GraphQL value literal. Variables ($name) are
 // allowed; for the const-context grammar use [ParseConstValue].
 func ParseValue(body string, opts ...Option) (ast.Value, error) {

--- a/parser/api.go
+++ b/parser/api.go
@@ -10,14 +10,30 @@ func Parse(body string, opts ...Option) (*ast.Document, error) {
 }
 
 // ParseSource parses a GraphQL document from src.
+//
+// In the default fail-fast mode the first syntax error aborts and the
+// returned *ast.Document is nil. With [WithRecovery], the parser collects
+// every syntax error it encounters and returns a partial document plus a
+// non-nil [ParseErrors]; the document may contain Bad{Definition,Field,Value,
+// Type} placeholder nodes where the parser had to resynchronize.
 func ParseSource(src *ast.Source, opts ...Option) (*ast.Document, error) {
 	p := newParser(src, opts)
 	doc, err := p.parseDocument()
 	if err != nil {
-		return nil, err
+		if p.cfg.recovery {
+			_ = p.recordError(err)
+		} else {
+			return nil, err
+		}
 	}
 	if err := p.expectEOF(); err != nil {
-		return nil, err
+		if !p.cfg.recovery {
+			return nil, err
+		}
+		_ = p.recordError(err)
+	}
+	if p.cfg.recovery && len(p.errors) > 0 {
+		return doc, ParseErrors(p.errors)
 	}
 	return doc, nil
 }

--- a/parser/api.go
+++ b/parser/api.go
@@ -1,0 +1,43 @@
+package parser
+
+import "github.com/bellbm/graphql-parser/ast"
+
+// ParseValue parses a single GraphQL value literal. Variables ($name) are
+// allowed; for the const-context grammar use [ParseConstValue].
+func ParseValue(body string, opts ...Option) (ast.Value, error) {
+	return parseValueEntry(body, false, opts)
+}
+
+// ParseConstValue parses a single GraphQL const value literal. Variables
+// ($name) are rejected at any nesting depth.
+func ParseConstValue(body string, opts ...Option) (ast.Value, error) {
+	return parseValueEntry(body, true, opts)
+}
+
+// ParseType parses a single GraphQL type reference (NamedType, ListType, or
+// NonNullType).
+func ParseType(body string, opts ...Option) (ast.Type, error) {
+	src := &ast.Source{Body: body, Name: "GraphQL"}
+	p := newParser(src, opts)
+	t, err := p.parseTypeReference()
+	if err != nil {
+		return nil, err
+	}
+	if err := p.expectEOF(); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func parseValueEntry(body string, isConst bool, opts []Option) (ast.Value, error) {
+	src := &ast.Source{Body: body, Name: "GraphQL"}
+	p := newParser(src, opts)
+	v, err := p.parseValueLiteral(isConst)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.expectEOF(); err != nil {
+		return nil, err
+	}
+	return v, nil
+}

--- a/parser/api.go
+++ b/parser/api.go
@@ -1,6 +1,6 @@
 package parser
 
-import "github.com/bellbm/graphql-parser/ast"
+import "github.com/brian-bell/graphql-parser/ast"
 
 // Parse parses a GraphQL source document and returns its [ast.Document].
 // The source is wrapped in an ast.Source named "GraphQL" for error messages;

--- a/parser/benchmark_test.go
+++ b/parser/benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 const tinyQuery = `query GetUser($id: ID!) { user(id: $id) { id name email } }`

--- a/parser/benchmark_test.go
+++ b/parser/benchmark_test.go
@@ -1,0 +1,144 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+const tinyQuery = `query GetUser($id: ID!) { user(id: $id) { id name email } }`
+
+const midSchema = `
+"""User account."""
+type User implements Node {
+	id: ID!
+	name(format: NameFormat = LONG): String!
+	email: String
+	friends(first: Int, after: String): UserConnection!
+	posts(filter: PostFilter): [Post!]!
+}
+
+type Post {
+	id: ID!
+	title: String!
+	body: String!
+	author: User!
+	tags: [String!]!
+	createdAt: DateTime!
+}
+
+type UserConnection {
+	edges: [UserEdge!]!
+	pageInfo: PageInfo!
+}
+
+type UserEdge {
+	cursor: String!
+	node: User!
+}
+
+type PageInfo {
+	hasNextPage: Boolean!
+	endCursor: String
+}
+
+input PostFilter {
+	tag: String
+	author: ID
+}
+
+enum NameFormat { SHORT LONG }
+
+interface Node {
+	id: ID!
+}
+
+union SearchResult = User | Post
+
+scalar DateTime
+
+directive @auth(role: Role!) on FIELD_DEFINITION | OBJECT
+
+type Query {
+	user(id: ID!): User
+	posts(filter: PostFilter): [Post!]!
+	search(q: String!): [SearchResult!]!
+}
+
+schema { query: Query }
+`
+
+func largeSchema() string {
+	// Synthesize a large schema by repeating the mid schema with renamed types.
+	var sb strings.Builder
+	for i := range 50 {
+		s := strings.ReplaceAll(midSchema, "User", "U"+itoa(i))
+		s = strings.ReplaceAll(s, "Post", "P"+itoa(i))
+		sb.WriteString(s)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [10]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(buf[pos:])
+}
+
+func BenchmarkParseTinyQuery(b *testing.B) {
+	body := tinyQuery
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	for b.Loop() {
+		_, err := parser.Parse(body)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseMidSchema(b *testing.B) {
+	body := midSchema
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	for b.Loop() {
+		_, err := parser.Parse(body)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseLargeSchema(b *testing.B) {
+	body := largeSchema()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	for b.Loop() {
+		_, err := parser.Parse(body)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseTinyQuery_WithComments(b *testing.B) {
+	body := "# leading\n" + tinyQuery
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	for b.Loop() {
+		_, err := parser.Parse(body, parser.WithComments())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -1,0 +1,101 @@
+package parser
+
+import (
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+// drainComments consumes any pending COMMENT tokens at the current lexer
+// position into p.pendingLeading. Called from peek/advance whenever
+// preserveComments is on; a no-op otherwise (the lexer doesn't emit
+// COMMENT tokens unless PreserveComments is set).
+func (p *parser) drainComments() {
+	if !p.cfg.preserveComments {
+		return
+	}
+	for {
+		tok, err := p.lex.Peek()
+		if err != nil || tok.Kind != lexer.COMMENT {
+			return
+		}
+		consumed, err := p.lex.Next()
+		if err != nil {
+			return
+		}
+		p.pendingLeading = append(p.pendingLeading, &ast.Comment{
+			Text: consumed.Value,
+			Loc: &ast.Loc{
+				Start:  consumed.Start,
+				End:    consumed.End,
+				Source: p.source,
+			},
+		})
+	}
+}
+
+// attachLeadingComments writes the given comment slice onto a node's
+// Comments.Leading field. No-op when leading is empty or the node has no
+// Comments field (e.g. a Type reference).
+func attachLeadingComments(n ast.Node, leading []*ast.Comment) {
+	if len(leading) == 0 || n == nil {
+		return
+	}
+	cg := commentGroupOf(n)
+	if cg == nil {
+		return
+	}
+	if *cg == nil {
+		*cg = &ast.CommentGroup{}
+	}
+	(*cg).Leading = append((*cg).Leading, leading...)
+}
+
+// commentGroupOf returns a pointer to the Comments field of n, or nil if n
+// has no such field.
+func commentGroupOf(n ast.Node) **ast.CommentGroup {
+	switch v := n.(type) {
+	case *ast.Document:
+		return &v.Comments
+	case *ast.OperationDefinition:
+		return &v.Comments
+	case *ast.FragmentDefinition:
+		return &v.Comments
+	case *ast.SchemaDefinition:
+		return &v.Comments
+	case *ast.SchemaExtension:
+		return &v.Comments
+	case *ast.ScalarTypeDefinition:
+		return &v.Comments
+	case *ast.ScalarTypeExtension:
+		return &v.Comments
+	case *ast.ObjectTypeDefinition:
+		return &v.Comments
+	case *ast.ObjectTypeExtension:
+		return &v.Comments
+	case *ast.InterfaceTypeDefinition:
+		return &v.Comments
+	case *ast.InterfaceTypeExtension:
+		return &v.Comments
+	case *ast.UnionTypeDefinition:
+		return &v.Comments
+	case *ast.UnionTypeExtension:
+		return &v.Comments
+	case *ast.EnumTypeDefinition:
+		return &v.Comments
+	case *ast.EnumTypeExtension:
+		return &v.Comments
+	case *ast.InputObjectTypeDefinition:
+		return &v.Comments
+	case *ast.InputObjectTypeExtension:
+		return &v.Comments
+	case *ast.DirectiveDefinition:
+		return &v.Comments
+	case *ast.FieldDefinition:
+		return &v.Comments
+	case *ast.InputValueDefinition:
+		return &v.Comments
+	case *ast.EnumValueDefinition:
+		return &v.Comments
+	}
+	return nil
+}

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // drainComments consumes any pending COMMENT tokens at the current lexer

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -1,0 +1,156 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+func TestComments_OffByDefault(t *testing.T) {
+	body := `
+# leading comment
+type T {
+	# field comment
+	name: String
+}`
+	doc, err := parser.Parse(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	if def.Comments != nil {
+		t.Errorf("Comments should be nil when WithComments off; got %+v", def.Comments)
+	}
+	field := def.Fields.ForName("name")
+	if field.Comments != nil {
+		t.Errorf("field Comments should be nil; got %+v", field.Comments)
+	}
+}
+
+func TestComments_LeadingOnDefinition(t *testing.T) {
+	body := `
+# this is the type
+# with a multi-line comment
+type T { x: Int }`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	if def.Comments == nil || len(def.Comments.Leading) != 2 {
+		t.Fatalf("expected 2 leading comments; got %+v", def.Comments)
+	}
+	if def.Comments.Leading[0].Text != " this is the type" {
+		t.Errorf("leading[0].Text = %q", def.Comments.Leading[0].Text)
+	}
+	if def.Comments.Leading[1].Text != " with a multi-line comment" {
+		t.Errorf("leading[1].Text = %q", def.Comments.Leading[1].Text)
+	}
+}
+
+func TestComments_LeadingOnField(t *testing.T) {
+	body := `
+type T {
+	# the id
+	id: ID!
+	# the name
+	# (display only)
+	name: String
+}`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	id := def.Fields.ForName("id")
+	if id.Comments == nil || len(id.Comments.Leading) != 1 || id.Comments.Leading[0].Text != " the id" {
+		t.Errorf("id field leading comments wrong: %+v", id.Comments)
+	}
+	name := def.Fields.ForName("name")
+	if name.Comments == nil || len(name.Comments.Leading) != 2 {
+		t.Errorf("name field leading comments wrong: %+v", name.Comments)
+	}
+}
+
+func TestComments_LeadingOnEnumValue(t *testing.T) {
+	body := `
+enum Color {
+	# red
+	RED
+	# green
+	GREEN
+}`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	enum := doc.Definitions[0].(*ast.EnumTypeDefinition)
+	red := enum.Values.ForName("RED")
+	if red.Comments == nil || len(red.Comments.Leading) != 1 {
+		t.Errorf("RED comments: %+v", red.Comments)
+	}
+}
+
+func TestComments_LeadingOnArgumentDefinition(t *testing.T) {
+	body := `
+type T {
+	field(
+		# the first arg
+		first: Int
+		# the second arg
+		second: String
+	): Boolean
+}`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	f := def.Fields.ForName("field")
+	first := f.Arguments.ForName("first")
+	if first.Comments == nil || len(first.Comments.Leading) != 1 {
+		t.Errorf("first arg comments: %+v", first.Comments)
+	}
+}
+
+func TestComments_OffInvariance_ASTUnchanged(t *testing.T) {
+	body := `
+# comment
+type T {
+	# comment
+	x: Int
+}`
+	docOff, err := parser.Parse(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	docOn, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Modulo Comments fields, the structure should be identical.
+	defOff := docOff.Definitions[0].(*ast.ObjectTypeDefinition)
+	defOn := docOn.Definitions[0].(*ast.ObjectTypeDefinition)
+	if defOff.Name != defOn.Name {
+		t.Errorf("Name differs")
+	}
+	if len(defOff.Fields) != len(defOn.Fields) {
+		t.Errorf("Fields len differs: %d vs %d", len(defOff.Fields), len(defOn.Fields))
+	}
+	if defOff.Loc.Start != defOn.Loc.Start || defOff.Loc.End != defOn.Loc.End {
+		t.Errorf("Loc differs: %+v vs %+v", defOff.Loc, defOn.Loc)
+	}
+}
+
+func TestComments_NoComments_NoCommentGroup(t *testing.T) {
+	body := `type T { x: Int }`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	if def.Comments != nil {
+		t.Errorf("Comments should be nil when there are no comments; got %+v", def.Comments)
+	}
+}

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -3,8 +3,8 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 func TestComments_OffByDefault(t *testing.T) {

--- a/parser/corpus_test.go
+++ b/parser/corpus_test.go
@@ -1,0 +1,244 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+// This file ports a representative slice of the graphql-js parser /
+// lexer / schema-parser test corpus. See
+// parser/testdata/graphql-js/README.md for the conformance bar and the
+// process for adding cases.
+
+// ----- Parser ---------------------------------------------------------------
+
+type parseAcceptCase struct {
+	name string
+	body string
+}
+
+var parserAcceptCases = []parseAcceptCase{
+	{"anonymous query shorthand", "{ field }"},
+	{"named query", "query MyQuery { field }"},
+	{"variables", "query Q($x: Int) { field(x: $x) }"},
+	{"variable with default", "query Q($x: Int = 1) { field(x: $x) }"},
+	{"directive on operation", "query Q @cached { field }"},
+	{"mutation", "mutation { update }"},
+	{"subscription", "subscription { events }"},
+	{"fragment definition", "fragment F on T { x }"},
+	{"fragment spread", "{ ...F }"},
+	{"inline fragment with type", "{ ... on T { x } }"},
+	{"inline fragment without type", "{ ... { x } }"},
+	{"inline fragment with directive only", "{ ... @skip(if: true) { x } }"},
+	{"alias", "{ short: longName }"},
+	{"nested selections", "{ a { b { c } } }"},
+	{"arguments mixed types", `{ f(int: 1, float: 1.5, str: "hi", bool: true, n: null, en: ENUM, lst: [1,2], obj: {a: 1}) }`},
+	{"comma is whitespace", "{ a, b, c }"},
+	{"newlines OK", "{\n  a\n  b\n}"},
+	{"BOM at start", "\ufeff{ x }"},
+	{"comment ignored", "# leading\n{ x }"},
+	{"empty list", "{ f(x: []) }"},
+	{"empty object", "{ f(x: {}) }"},
+	{"variable only at value position", "{ f(x: $v) }"},
+	{"directive args use values", `{ f @dir(a: 1, b: "x") }`},
+	{"multiple definitions", "{ x } query Q { y } fragment F on T { z }"},
+}
+
+func TestCorpus_ParserAccept(t *testing.T) {
+	for _, c := range parserAcceptCases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := parser.Parse(c.body); err != nil {
+				t.Errorf("Parse(%q) errored: %v", c.body, err)
+			}
+		})
+	}
+}
+
+type parseRejectCase struct {
+	name       string
+	body       string
+	wantPhrase string // substring of the error message
+}
+
+var parserRejectCases = []parseRejectCase{
+	{"empty document", "", "Expected"},
+	{"unexpected character", "{ a $ }", "Expected"},
+	{"unexpected EOF in selection", "{ a", "Expected"},
+	{"empty selection set", "{}", "Expected"},
+	{"empty arguments", "{ a() }", "Expected"},
+	{"empty variable definitions", "query () { x }", "Expected"},
+	{"variable in default", "query ($a: Int = $b) { x }", "Unexpected variable"},
+	{"reserved fragment name 'on'", "fragment on on T { x }", "Unexpected"},
+	{"missing colon in argument", "{ a(b 1) }", "Expected :"},
+	{"missing colon in object field", `{ f(x: { a 1 }) }`, "Expected :"},
+	{"trailing tokens", "query Q { x } extra", "Unexpected"},
+	{"non-null on non-null", "query Q($x: Int!!) { f }", "Expected"},
+	{"unmatched bracket", "query Q($x: [Int) { f }", "Expected"},
+	{"unmatched paren", "query Q($x: Int { f }", "Expected"},
+	{"bad number", "{ a(x: 01) }", "Invalid number"},
+}
+
+func TestCorpus_ParserReject(t *testing.T) {
+	for _, c := range parserRejectCases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := parser.Parse(c.body)
+			if err == nil {
+				t.Fatalf("Parse(%q) accepted; expected an error", c.body)
+			}
+			if !strings.Contains(err.Error(), c.wantPhrase) {
+				t.Errorf("Parse(%q) error %q does not contain %q",
+					c.body, err.Error(), c.wantPhrase)
+			}
+		})
+	}
+}
+
+// ----- Lexer (via the parser, since lexer tests are in lexer_test.go) ------
+
+type lexAcceptCase struct {
+	name  string
+	body  string
+	check func(t *testing.T, doc *ast.Document)
+}
+
+var lexerCases = []lexAcceptCase{
+	{
+		"surrogate pair fixed escape",
+		`{ f(x: "😀") }`,
+		func(t *testing.T, doc *ast.Document) {
+			arg := doc.Definitions[0].(*ast.OperationDefinition).
+				SelectionSet.Selections[0].(*ast.Field).Arguments[0]
+			if sv, ok := arg.Value.(*ast.StringValue); !ok || sv.Value != "\U0001F600" {
+				t.Errorf("expected emoji; got %v", arg.Value)
+			}
+		},
+	},
+	{
+		"variable Unicode escape",
+		`{ f(x: "\u{1F600}") }`,
+		func(t *testing.T, doc *ast.Document) {
+			arg := doc.Definitions[0].(*ast.OperationDefinition).
+				SelectionSet.Selections[0].(*ast.Field).Arguments[0]
+			if sv, ok := arg.Value.(*ast.StringValue); !ok || sv.Value != "\U0001F600" {
+				t.Errorf("expected emoji; got %v", arg.Value)
+			}
+		},
+	},
+	{
+		"block string dedent",
+		"{ f(x: \"\"\"\n  a\n    b\n  \"\"\") }",
+		func(t *testing.T, doc *ast.Document) {
+			arg := doc.Definitions[0].(*ast.OperationDefinition).
+				SelectionSet.Selections[0].(*ast.Field).Arguments[0]
+			sv := arg.Value.(*ast.StringValue)
+			if !sv.Block {
+				t.Error("expected Block: true")
+			}
+			if sv.Value != "a\n  b" {
+				t.Errorf("got %q; want %q", sv.Value, "a\n  b")
+			}
+		},
+	},
+	{
+		"block string escaped triple",
+		"{ f(x: \"\"\"\\\"\"\"hi\"\"\") }",
+		func(t *testing.T, doc *ast.Document) {
+			arg := doc.Definitions[0].(*ast.OperationDefinition).
+				SelectionSet.Selections[0].(*ast.Field).Arguments[0]
+			sv := arg.Value.(*ast.StringValue)
+			if sv.Value != `"""hi` {
+				t.Errorf("got %q", sv.Value)
+			}
+		},
+	},
+}
+
+func TestCorpus_Lexer(t *testing.T) {
+	for _, c := range lexerCases {
+		t.Run(c.name, func(t *testing.T) {
+			doc, err := parser.Parse(c.body)
+			if err != nil {
+				t.Fatalf("Parse(%q) errored: %v", c.body, err)
+			}
+			c.check(t, doc)
+		})
+	}
+}
+
+// ----- Schema parser --------------------------------------------------------
+
+var schemaAcceptCases = []parseAcceptCase{
+	{"schema definition", "schema { query: Query }"},
+	{"schema with directive", "schema @secured { query: Query }"},
+	{"scalar", "scalar URL"},
+	{"scalar with directive", `scalar URL @specifiedBy(url: "https://x")`},
+	{"object type", "type T { x: Int }"},
+	{"object type with description", `"the type" type T { x: Int }`},
+	{"object type with block description", "\"\"\"\nblock\n\"\"\"\ntype T { x: Int }"},
+	{"object implements interfaces", "type T implements A & B { x: Int }"},
+	{"object implements with leading amp", "type T implements & A & B { x: Int }"},
+	{"interface type", "interface I { x: Int }"},
+	{"interface implementing interface", "interface I implements N { id: ID! }"},
+	{"union type", "union U = A | B"},
+	{"union with leading pipe", "union U = | A | B"},
+	{"union no members", "union Empty"},
+	{"enum type", "enum E { A B C }"},
+	{"enum with description", "enum Color { \"red\" RED \"green\" GREEN }"},
+	{"input type", "input In { x: Int = 1 }"},
+	{"input with directives", "input In { x: Int = 1 @check }"},
+	{"directive definition", "directive @auth on FIELD"},
+	{"directive with args", "directive @auth(role: Role!) on FIELD"},
+	{"directive repeatable", "directive @tag(name: String!) repeatable on OBJECT"},
+	{"directive multiple locations", "directive @x on FIELD | OBJECT | ARGUMENT_DEFINITION"},
+	{"schema extension", "extend schema @secured { mutation: M }"},
+	{"object extension", "extend type T { y: Int }"},
+	{"object extension implements only", "extend type T implements I"},
+	{"interface extension", "extend interface I { y: Int }"},
+	{"union extension", "extend union U = C"},
+	{"enum extension", "extend enum E { D }"},
+	{"input extension", "extend input In { y: Int }"},
+	{"scalar extension directive", "extend scalar URL @new"},
+}
+
+func TestCorpus_SchemaAccept(t *testing.T) {
+	for _, c := range schemaAcceptCases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := parser.Parse(c.body); err != nil {
+				t.Errorf("Parse(%q) errored: %v", c.body, err)
+			}
+		})
+	}
+}
+
+var schemaRejectCases = []parseRejectCase{
+	{"description on extension", `"x" extend type T { y: Int }`, "description"},
+	{"empty schema extension", "extend schema", "extension must define"},
+	{"empty type extension", "extend type T", "extension must define"},
+	{"unknown directive location", "directive @x on FROBNICATE", "directive location"},
+	{"reserved enum value true", "enum E { true }", "true, false, or null"},
+	{"reserved enum value false", "enum E { false }", "true, false, or null"},
+	{"reserved enum value null", "enum E { null }", "true, false, or null"},
+	{"missing operation type", "schema { }", "operation type"},
+	{"missing fields after type", "type T { }", "field definition"},
+	{"empty arguments definition", "type T { f(): Int }", "argument definition"},
+	{"empty input fields", "input In { }", "input field definition"},
+	{"description before extension keyword", `"x" extend scalar URL @x`, "description"},
+}
+
+func TestCorpus_SchemaReject(t *testing.T) {
+	for _, c := range schemaRejectCases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := parser.Parse(c.body)
+			if err == nil {
+				t.Fatalf("Parse(%q) accepted; expected an error", c.body)
+			}
+			if !strings.Contains(err.Error(), c.wantPhrase) {
+				t.Errorf("Parse(%q) error %q does not contain %q",
+					c.body, err.Error(), c.wantPhrase)
+			}
+		})
+	}
+}

--- a/parser/corpus_test.go
+++ b/parser/corpus_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 // This file ports a representative slice of the graphql-js parser /

--- a/parser/document.go
+++ b/parser/document.go
@@ -17,14 +17,26 @@ func (p *parser) parseDocument() (*ast.Document, error) {
 	for {
 		tok, err := p.peek()
 		if err != nil {
+			if p.cfg.recovery {
+				_ = p.recordError(err)
+				p.skipToDefinitionStart()
+				continue
+			}
 			return nil, err
 		}
 		if tok.Kind == lexer.EOF {
 			break
 		}
+		defStart := tok.Start
 		def, err := p.parseDefinition()
 		if err != nil {
-			return nil, err
+			if !p.recordError(err) {
+				return nil, err
+			}
+			se, _ := err.(*ast.SyntaxError)
+			p.skipToDefinitionStart()
+			defs = append(defs, &ast.BadDefinition{Err: se, Loc: p.loc(defStart)})
+			continue
 		}
 		defs = append(defs, def)
 	}

--- a/parser/document.go
+++ b/parser/document.go
@@ -28,6 +28,10 @@ func (p *parser) parseDocument() (*ast.Document, error) {
 			break
 		}
 		defStart := tok.Start
+		// Capture the leading-comment buffer for THIS definition before any
+		// inner parser (e.g. its first FieldDefinition) can take it.
+		defLeading := p.pendingLeading
+		p.pendingLeading = nil
 		def, err := p.parseDefinition()
 		if err != nil {
 			if !p.recordError(err) {
@@ -38,6 +42,7 @@ func (p *parser) parseDocument() (*ast.Document, error) {
 			defs = append(defs, &ast.BadDefinition{Err: se, Loc: p.loc(defStart)})
 			continue
 		}
+		attachLeadingComments(def, defLeading)
 		defs = append(defs, def)
 	}
 	if len(defs) == 0 {

--- a/parser/document.go
+++ b/parser/document.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // parseDocument consumes the full source and returns a Document containing

--- a/parser/document.go
+++ b/parser/document.go
@@ -1,0 +1,78 @@
+package parser
+
+import (
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+// parseDocument consumes the full source and returns a Document containing
+// one or more Definitions. Empty input is an error per spec.
+func (p *parser) parseDocument() (*ast.Document, error) {
+	first, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	start := first.Start
+	var defs ast.DefinitionList
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.EOF {
+			break
+		}
+		def, err := p.parseDefinition()
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, def)
+	}
+	if len(defs) == 0 {
+		return nil, p.errAtTok(first, "Expected at least one definition.")
+	}
+	return &ast.Document{
+		Definitions: defs,
+		Loc:         &ast.Loc{Start: start, End: p.lastEnd, Source: p.source},
+	}, nil
+}
+
+// parseDefinition dispatches on the first token of a definition. Phase 6
+// handles executable definitions (operations and fragments) and the bare
+// "{ ... }" shorthand operation; phase 7 extends this to type-system
+// definitions and extensions.
+func (p *parser) parseDefinition() (ast.Definition, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	switch tok.Kind {
+	case lexer.LBRACE:
+		return p.parseShorthandOperation()
+	case lexer.NAME:
+		switch tok.Value {
+		case "query", "mutation", "subscription":
+			return p.parseOperationDefinition()
+		case "fragment":
+			return p.parseFragmentDefinition()
+		}
+		// Type-system keywords are handled in phase 7. For now, fall through.
+		def, ok, err := p.parseTypeSystemDefinitionOrExtension()
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return def, nil
+		}
+	case lexer.STRING:
+		// A leading string is a description for a type-system definition; phase 7.
+		def, ok, err := p.parseTypeSystemDefinitionOrExtension()
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return def, nil
+		}
+	}
+	return nil, p.errAtTok(tok, "Unexpected "+describeToken(tok)+".")
+}

--- a/parser/error.go
+++ b/parser/error.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bellbm/graphql-parser/ast"
+
+// ParseError is the syntax-error type produced by all Parse* entry points.
+// It is currently an alias for ast.SyntaxError; phase 8 enhances the shared
+// Error() format with a graphql-js-style source-line snippet and caret pointer.
+type ParseError = ast.SyntaxError

--- a/parser/error.go
+++ b/parser/error.go
@@ -1,8 +1,44 @@
 package parser
 
-import "github.com/bellbm/graphql-parser/ast"
+import (
+	"strings"
+
+	"github.com/bellbm/graphql-parser/ast"
+)
 
 // ParseError is the syntax-error type produced by all Parse* entry points.
-// It is currently an alias for ast.SyntaxError; phase 8 enhances the shared
-// Error() format with a graphql-js-style source-line snippet and caret pointer.
+// It is an alias for ast.SyntaxError; the underlying type is shared with the
+// lexer so callers don't need to handle two error types.
 type ParseError = ast.SyntaxError
+
+// ParseErrors aggregates multiple ParseErrors, used when [WithRecovery] is
+// enabled. It implements error and supports errors.Is / errors.As / errors.Unwrap
+// for unwrapping into the underlying slice.
+type ParseErrors []*ParseError
+
+// Error renders one error per line.
+func (es ParseErrors) Error() string {
+	if len(es) == 0 {
+		return "no syntax errors"
+	}
+	if len(es) == 1 {
+		return es[0].Error()
+	}
+	var sb strings.Builder
+	for i, e := range es {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(e.Error())
+	}
+	return sb.String()
+}
+
+// Unwrap exposes the underlying ParseError slice for errors.Is / errors.As.
+func (es ParseErrors) Unwrap() []error {
+	out := make([]error, len(es))
+	for i, e := range es {
+		out[i] = e
+	}
+	return out
+}

--- a/parser/error.go
+++ b/parser/error.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"strings"
 
-	"github.com/bellbm/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/ast"
 )
 
 // ParseError is the syntax-error type produced by all Parse* entry points.

--- a/parser/executable_test.go
+++ b/parser/executable_test.go
@@ -1,0 +1,295 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+func mustParse(t *testing.T, body string) *ast.Document {
+	t.Helper()
+	doc, err := parser.Parse(body)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", body, err)
+	}
+	return doc
+}
+
+func TestParse_ShorthandQuery(t *testing.T) {
+	doc := mustParse(t, "{ hello }")
+	if len(doc.Definitions) != 1 {
+		t.Fatalf("definitions = %d; want 1", len(doc.Definitions))
+	}
+	op, ok := doc.Definitions[0].(*ast.OperationDefinition)
+	if !ok {
+		t.Fatalf("got %T; want *ast.OperationDefinition", doc.Definitions[0])
+	}
+	if op.Operation != ast.OperationQuery {
+		t.Errorf("op = %q; want query", op.Operation)
+	}
+	if op.Name != "" {
+		t.Errorf("Name = %q; want empty", op.Name)
+	}
+	if op.SelectionSet == nil || len(op.SelectionSet.Selections) != 1 {
+		t.Fatalf("selection set wrong: %+v", op.SelectionSet)
+	}
+	f, ok := op.SelectionSet.Selections[0].(*ast.Field)
+	if !ok {
+		t.Fatalf("got %T; want *ast.Field", op.SelectionSet.Selections[0])
+	}
+	if f.Name != "hello" {
+		t.Errorf("Name = %q; want hello", f.Name)
+	}
+}
+
+func TestParse_NamedQuery(t *testing.T) {
+	doc := mustParse(t, "query MyQuery { hello }")
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	if op.Operation != ast.OperationQuery {
+		t.Errorf("op = %q; want query", op.Operation)
+	}
+	if op.Name != "MyQuery" {
+		t.Errorf("Name = %q; want MyQuery", op.Name)
+	}
+}
+
+func TestParse_Mutation(t *testing.T) {
+	doc := mustParse(t, "mutation { update }")
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	if op.Operation != ast.OperationMutation {
+		t.Errorf("op = %q; want mutation", op.Operation)
+	}
+}
+
+func TestParse_Subscription(t *testing.T) {
+	doc := mustParse(t, "subscription Sub { events }")
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	if op.Operation != ast.OperationSubscription {
+		t.Errorf("op = %q; want subscription", op.Operation)
+	}
+	if op.Name != "Sub" {
+		t.Errorf("Name = %q; want Sub", op.Name)
+	}
+}
+
+func TestParse_VariablesAndDefaults(t *testing.T) {
+	body := `query Q($id: ID!, $count: Int = 10, $tags: [String!]! = ["a","b"]) { x }`
+	doc := mustParse(t, body)
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	if len(op.VariableDefinitions) != 3 {
+		t.Fatalf("vars = %d; want 3", len(op.VariableDefinitions))
+	}
+	id := op.VariableDefinitions.ForName("id")
+	if id == nil {
+		t.Fatal("missing $id")
+	}
+	if _, ok := id.Type.(*ast.NonNullType); !ok {
+		t.Errorf("$id type = %T; want *ast.NonNullType", id.Type)
+	}
+	if id.DefaultValue != nil {
+		t.Error("$id has unexpected default")
+	}
+	count := op.VariableDefinitions.ForName("count")
+	if count == nil || count.DefaultValue == nil {
+		t.Fatal("missing $count or its default")
+	}
+	if iv, ok := count.DefaultValue.(*ast.IntValue); !ok || iv.Value != "10" {
+		t.Errorf("count default = %T %v; want IntValue 10", count.DefaultValue, count.DefaultValue)
+	}
+}
+
+func TestParse_VariableDefaultRejectsVariable(t *testing.T) {
+	// Default values are const, so $other is not allowed.
+	if _, err := parser.Parse(`query ($a: Int = $other) { x }`); err == nil {
+		t.Error("expected error: variable in default value")
+	}
+}
+
+func TestParse_Directives(t *testing.T) {
+	doc := mustParse(t, `query @deprecated(reason: "old") @cacheControl { x @include(if: true) }`)
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	if len(op.Directives) != 2 {
+		t.Fatalf("op directives = %d; want 2", len(op.Directives))
+	}
+	if op.Directives.ForName("deprecated") == nil {
+		t.Error("missing @deprecated")
+	}
+	if op.Directives.ForName("cacheControl") == nil {
+		t.Error("missing @cacheControl")
+	}
+	dep := op.Directives.ForName("deprecated")
+	if len(dep.Arguments) != 1 || dep.Arguments[0].Name != "reason" {
+		t.Errorf("deprecated args = %v", dep.Arguments)
+	}
+
+	f := op.SelectionSet.Selections[0].(*ast.Field)
+	inc := f.Directives.ForName("include")
+	if inc == nil {
+		t.Fatal("missing @include on field")
+	}
+	if iv := inc.Arguments.ForName("if"); iv == nil {
+		t.Fatal("missing if: arg")
+	}
+}
+
+func TestParse_FieldAliasAndArguments(t *testing.T) {
+	doc := mustParse(t, `{ short: longFieldName(a: 1, b: $v) }`)
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	f := op.SelectionSet.Selections[0].(*ast.Field)
+	if f.Alias != "short" {
+		t.Errorf("alias = %q; want short", f.Alias)
+	}
+	if f.Name != "longFieldName" {
+		t.Errorf("name = %q; want longFieldName", f.Name)
+	}
+	if len(f.Arguments) != 2 {
+		t.Errorf("args = %d; want 2", len(f.Arguments))
+	}
+}
+
+func TestParse_NestedSelectionSets(t *testing.T) {
+	doc := mustParse(t, `{ user { name address { city } } }`)
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	user := op.SelectionSet.Selections[0].(*ast.Field)
+	if user.SelectionSet == nil {
+		t.Fatal("user has no nested selection set")
+	}
+	if len(user.SelectionSet.Selections) != 2 {
+		t.Errorf("user children = %d; want 2", len(user.SelectionSet.Selections))
+	}
+	address := user.SelectionSet.Selections[1].(*ast.Field)
+	if address.SelectionSet == nil || len(address.SelectionSet.Selections) != 1 {
+		t.Errorf("address selection set wrong: %+v", address.SelectionSet)
+	}
+}
+
+func TestParse_FragmentSpread(t *testing.T) {
+	doc := mustParse(t, `{ ...UserFields ...OtherFields @skip(if: false) }`)
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	if len(op.SelectionSet.Selections) != 2 {
+		t.Fatalf("selections = %d; want 2", len(op.SelectionSet.Selections))
+	}
+	a, ok := op.SelectionSet.Selections[0].(*ast.FragmentSpread)
+	if !ok || a.Name != "UserFields" {
+		t.Errorf("first: got %T %v; want FragmentSpread UserFields", op.SelectionSet.Selections[0], op.SelectionSet.Selections[0])
+	}
+	b := op.SelectionSet.Selections[1].(*ast.FragmentSpread)
+	if b.Name != "OtherFields" || len(b.Directives) != 1 {
+		t.Errorf("second wrong: %+v", b)
+	}
+}
+
+func TestParse_InlineFragmentWithCondition(t *testing.T) {
+	doc := mustParse(t, `{ ... on User { name } }`)
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	frag, ok := op.SelectionSet.Selections[0].(*ast.InlineFragment)
+	if !ok {
+		t.Fatalf("got %T; want *ast.InlineFragment", op.SelectionSet.Selections[0])
+	}
+	if frag.TypeCondition == nil || frag.TypeCondition.Name != "User" {
+		t.Errorf("type condition = %v; want NamedType User", frag.TypeCondition)
+	}
+}
+
+func TestParse_InlineFragmentWithoutCondition(t *testing.T) {
+	doc := mustParse(t, `{ ... @skip(if: true) { name } }`)
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	frag := op.SelectionSet.Selections[0].(*ast.InlineFragment)
+	if frag.TypeCondition != nil {
+		t.Errorf("type condition = %v; want nil", frag.TypeCondition)
+	}
+	if len(frag.Directives) != 1 {
+		t.Errorf("directives = %d; want 1", len(frag.Directives))
+	}
+}
+
+func TestParse_FragmentDefinition(t *testing.T) {
+	doc := mustParse(t, `fragment UserFields on User { id name }`)
+	frag := doc.Definitions[0].(*ast.FragmentDefinition)
+	if frag.Name != "UserFields" {
+		t.Errorf("name = %q; want UserFields", frag.Name)
+	}
+	if frag.TypeCondition.Name != "User" {
+		t.Errorf("cond = %v; want User", frag.TypeCondition)
+	}
+	if len(frag.SelectionSet.Selections) != 2 {
+		t.Errorf("selections = %d; want 2", len(frag.SelectionSet.Selections))
+	}
+}
+
+func TestParse_FragmentDefinitionRejectsOnAsName(t *testing.T) {
+	if _, err := parser.Parse(`fragment on on Foo { x }`); err == nil {
+		t.Error("expected error: fragment named 'on'")
+	}
+}
+
+func TestParse_MultipleDefinitions(t *testing.T) {
+	body := `query A { a } query B { b } fragment F on T { c }`
+	doc := mustParse(t, body)
+	if len(doc.Definitions) != 3 {
+		t.Errorf("defs = %d; want 3", len(doc.Definitions))
+	}
+}
+
+func TestParse_EmptyDocumentIsError(t *testing.T) {
+	if _, err := parser.Parse(""); err == nil {
+		t.Error("expected error for empty document")
+	}
+}
+
+func TestParse_EmptySelectionSetIsError(t *testing.T) {
+	if _, err := parser.Parse("{}"); err == nil {
+		t.Error("expected error: empty selection set")
+	}
+}
+
+func TestParse_EmptyArgumentsIsError(t *testing.T) {
+	if _, err := parser.Parse("{ field() }"); err == nil {
+		t.Error("expected error: empty arguments")
+	}
+}
+
+func TestParse_EmptyVariableDefinitionsIsError(t *testing.T) {
+	if _, err := parser.Parse("query () { x }"); err == nil {
+		t.Error("expected error: empty variable definitions")
+	}
+}
+
+func TestParse_DocumentLocCoversFullSource(t *testing.T) {
+	body := "  query Q { x }  "
+	doc := mustParse(t, body)
+	loc := doc.GetLoc()
+	if loc == nil {
+		t.Fatal("nil Loc")
+	}
+	if loc.Start != 2 {
+		t.Errorf("Start = %d; want 2 (skip leading whitespace)", loc.Start)
+	}
+	// End should land at the closing brace, not the trailing whitespace.
+	if loc.End != 15 {
+		t.Errorf("End = %d; want 15", loc.End)
+	}
+}
+
+func TestParse_ErrorMentionsExpectedToken(t *testing.T) {
+	_, err := parser.Parse("query")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "expected") {
+		t.Errorf("error %q does not say 'expected'", err.Error())
+	}
+}
+
+func TestParseSource_UsesProvidedName(t *testing.T) {
+	src := &ast.Source{Body: "{ x }", Name: "myfile.graphql"}
+	doc, err := parser.ParseSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.Loc.Source.Name != "myfile.graphql" {
+		t.Errorf("source name = %q; want myfile.graphql", doc.Loc.Source.Name)
+	}
+}

--- a/parser/executable_test.go
+++ b/parser/executable_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 func mustParse(t *testing.T, body string) *ast.Document {

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 // fuzzSeeds are a representative slice of inputs (mix of valid and broken)

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -1,0 +1,131 @@
+package parser_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+// fuzzSeeds are a representative slice of inputs (mix of valid and broken)
+// used to seed both FuzzParse and FuzzParseWithRecovery.
+var fuzzSeeds = []string{
+	"",
+	"{}",
+	"{ x }",
+	"query Q { x }",
+	"mutation M { do }",
+	"subscription S { events }",
+	"fragment F on T { x }",
+	"{ ...frag }",
+	"{ ... on T { x } }",
+	"{ a(x: 1, y: $v) @dir }",
+	`{ s: "hi", b: """block""" }`,
+	"query Q($v: Int = 1) @dir { x }",
+	"type T { id: ID! name(arg: Int = 1): String }",
+	"interface I implements & A & B { x: Int }",
+	"union U = A | B | C",
+	"enum E { A B C }",
+	"input In { x: Int = 1 }",
+	"scalar URL @specifiedBy(url: \"https://x\")",
+	"directive @auth(role: Role!) repeatable on FIELD | OBJECT",
+	"extend type T { y: Int }",
+	`"desc" type T { x: Int }`,
+	`"""multi
+	line""" type T { x: Int }`,
+	// Intentionally malformed inputs:
+	"query",
+	"{",
+	"{ a (",
+	"type T {",
+	"type T { x: }",
+	"type T implements",
+	"\"unterminated",
+	"\"\"\"unterminated block",
+	"directive @x on BOGUS",
+	"{ a $bogus b }",
+	"01",
+	"1.0.0",
+	"\\u{ZZ}",
+	// Edge cases that have historically broken parsers:
+	"{ a, b, c }",
+	"{ a # comment\n b }",
+	"#only a comment\n",
+	"\xef\xbb\xbf{ x }", // BOM
+}
+
+// FuzzParse exercises the default (fail-fast) parser. Properties:
+//   - never panics
+//   - if (doc, nil) is returned then doc is non-nil
+//   - if an error is returned it is a *parser.ParseError
+func FuzzParse(f *testing.F) {
+	for _, s := range fuzzSeeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, body string) {
+		doc, err := parser.Parse(body)
+		if err == nil && doc == nil {
+			t.Errorf("Parse returned (nil, nil) for %q", body)
+		}
+		if err != nil {
+			var pe *parser.ParseError
+			if !errors.As(err, &pe) {
+				t.Errorf("Parse returned %T (want *ParseError) for %q", err, body)
+			}
+		}
+	})
+}
+
+// FuzzParseWithRecovery exercises the recovery-mode parser. Properties:
+//   - never panics
+//   - always returns a non-nil document (recovery should produce a partial AST)
+//     OR returns nil when the input has no definitions at all
+//   - any error is a parser.ParseErrors (a slice wrapper of ParseError)
+func FuzzParseWithRecovery(f *testing.F) {
+	for _, s := range fuzzSeeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, body string) {
+		doc, err := parser.Parse(body, parser.WithRecovery())
+		if err != nil {
+			var es parser.ParseErrors
+			if !errors.As(err, &es) && !isParseError(err) {
+				t.Errorf("Parse(WithRecovery) returned %T for %q", err, body)
+			}
+		}
+		// doc may be nil for empty-input corner cases; that's fine.
+		_ = doc
+	})
+}
+
+func isParseError(err error) bool {
+	var pe *parser.ParseError
+	return errors.As(err, &pe)
+}
+
+// Also fuzz the partial-parse entry points.
+
+func FuzzParseValue(f *testing.F) {
+	for _, s := range []string{"", "1", "1.0", `"x"`, "true", "null", "[]", "{}",
+		`{a: 1, b: [2, 3]}`, "$v", "ENUM", "[$x, 1, true, null]"} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, body string) {
+		v, err := parser.ParseValue(body)
+		if err == nil && v == nil {
+			t.Errorf("ParseValue returned (nil, nil) for %q", body)
+		}
+	})
+}
+
+func FuzzParseType(f *testing.F) {
+	for _, s := range []string{"", "T", "[T]", "T!", "[T!]!", "[[[T]]]"} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, body string) {
+		ty, err := parser.ParseType(body)
+		if err == nil && ty == nil {
+			t.Errorf("ParseType returned (nil, nil) for %q", body)
+		}
+	})
+}

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // parseShorthandOperation parses a bare "{ ... }" as an anonymous query.

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -1,0 +1,293 @@
+package parser
+
+import (
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+// parseShorthandOperation parses a bare "{ ... }" as an anonymous query.
+func (p *parser) parseShorthandOperation() (*ast.OperationDefinition, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	start := tok.Start
+	set, err := p.parseSelectionSet()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.OperationDefinition{
+		Operation:    ast.OperationQuery,
+		SelectionSet: set,
+		Loc:          p.loc(start),
+	}, nil
+}
+
+// parseOperationDefinition parses "query|mutation|subscription Name?
+// VariableDefinitions? Directives? SelectionSet".
+func (p *parser) parseOperationDefinition() (*ast.OperationDefinition, error) {
+	keyword, err := p.advance()
+	if err != nil {
+		return nil, err
+	}
+	op := ast.OperationType(keyword.Value)
+
+	def := &ast.OperationDefinition{Operation: op}
+
+	// Optional Name.
+	if next, err := p.peek(); err != nil {
+		return nil, err
+	} else if next.Kind == lexer.NAME {
+		name, err := p.advance()
+		if err != nil {
+			return nil, err
+		}
+		def.Name = name.Value
+	}
+
+	// Optional VariableDefinitions.
+	if next, err := p.peek(); err != nil {
+		return nil, err
+	} else if next.Kind == lexer.LPAREN {
+		vars, err := p.parseVariableDefinitions()
+		if err != nil {
+			return nil, err
+		}
+		def.VariableDefinitions = vars
+	}
+
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, err
+	}
+	def.Directives = dirs
+
+	set, err := p.parseSelectionSet()
+	if err != nil {
+		return nil, err
+	}
+	def.SelectionSet = set
+	def.Loc = p.loc(keyword.Start)
+	return def, nil
+}
+
+// parseFragmentDefinition parses "fragment Name on NamedType Directives?
+// SelectionSet".
+func (p *parser) parseFragmentDefinition() (*ast.FragmentDefinition, error) {
+	keyword, err := p.expectKeyword("fragment")
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.parseFragmentName()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expectKeyword("on"); err != nil {
+		return nil, err
+	}
+	cond, err := p.parseNamedType()
+	if err != nil {
+		return nil, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, err
+	}
+	set, err := p.parseSelectionSet()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.FragmentDefinition{
+		Name:          name,
+		TypeCondition: cond,
+		Directives:    dirs,
+		SelectionSet:  set,
+		Loc:           p.loc(keyword.Start),
+	}, nil
+}
+
+// parseFragmentName accepts a Name that is not the reserved keyword "on".
+func (p *parser) parseFragmentName() (string, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return "", err
+	}
+	if tok.Kind != lexer.NAME {
+		return "", p.errAtTok(tok, "Expected fragment name, found "+describeToken(tok)+".")
+	}
+	if tok.Value == "on" {
+		return "", p.errAtTok(tok, "Unexpected Name \"on\".")
+	}
+	if _, err := p.advance(); err != nil {
+		return "", err
+	}
+	return tok.Value, nil
+}
+
+func (p *parser) parseNamedType() (*ast.NamedType, error) {
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.NamedType{Name: name.Value, Loc: p.loc(name.Start)}, nil
+}
+
+func (p *parser) parseVariableDefinitions() (ast.VariableDefinitionList, error) {
+	if _, err := p.expect(lexer.LPAREN); err != nil {
+		return nil, err
+	}
+	var out ast.VariableDefinitionList
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RPAREN {
+			break
+		}
+		v, err := p.parseVariableDefinition()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	if _, err := p.expect(lexer.RPAREN); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		// Spec: VariableDefinitions = ( VariableDefinition+ ) — at least one.
+		// Match graphql-js's error pointing at the closing paren.
+		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected variable definition.")
+	}
+	return out, nil
+}
+
+func (p *parser) parseVariableDefinition() (*ast.VariableDefinition, error) {
+	dollar, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	v, err := p.parseVariable()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(lexer.COLON); err != nil {
+		return nil, err
+	}
+	t, err := p.parseTypeReference()
+	if err != nil {
+		return nil, err
+	}
+	def := &ast.VariableDefinition{Variable: v, Type: t}
+	if _, ok, err := p.optional(lexer.EQUALS); err != nil {
+		return nil, err
+	} else if ok {
+		dv, err := p.parseValueLiteral(true)
+		if err != nil {
+			return nil, err
+		}
+		def.DefaultValue = dv
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, err
+	}
+	def.Directives = dirs
+	def.Loc = p.loc(dollar.Start)
+	return def, nil
+}
+
+// parseDirectives parses zero or more directives. isConst constrains directive
+// arguments to const values.
+func (p *parser) parseDirectives(isConst bool) (ast.DirectiveList, error) {
+	var out ast.DirectiveList
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind != lexer.AT {
+			break
+		}
+		d, err := p.parseDirective(isConst)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+func (p *parser) parseDirective(isConst bool) (*ast.Directive, error) {
+	at, err := p.expect(lexer.AT)
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	args, err := p.parseArguments(isConst)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.Directive{
+		Name:      name.Value,
+		Arguments: args,
+		Loc:       p.loc(at.Start),
+	}, nil
+}
+
+func (p *parser) parseArguments(isConst bool) (ast.ArgumentList, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	if tok.Kind != lexer.LPAREN {
+		return nil, nil
+	}
+	if _, err := p.advance(); err != nil {
+		return nil, err
+	}
+	var out ast.ArgumentList
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RPAREN {
+			break
+		}
+		a, err := p.parseArgument(isConst)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	if _, err := p.expect(lexer.RPAREN); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected argument.")
+	}
+	return out, nil
+}
+
+func (p *parser) parseArgument(isConst bool) (*ast.Argument, error) {
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(lexer.COLON); err != nil {
+		return nil, err
+	}
+	v, err := p.parseValueLiteral(isConst)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.Argument{
+		Name:  name.Value,
+		Value: v,
+		Loc:   p.loc(name.Start),
+	}, nil
+}

--- a/parser/options.go
+++ b/parser/options.go
@@ -1,14 +1,25 @@
 package parser
 
-// Option configures a parse operation. Future additions (e.g. WithRecovery,
-// WithComments, WithExperimental) will land here without API churn —
-// every Parse* entry point already accepts variadic options.
+// Option configures a parse operation. Future additions (e.g. WithComments,
+// WithExperimental) will land here without API churn — every Parse* entry
+// point already accepts variadic options.
 type Option func(*config)
 
 type config struct {
-	// recovery and preserveComments will be wired up by phases 11 and 12.
 	recovery         bool
 	preserveComments bool
+}
+
+// WithRecovery enables error recovery: the parser collects multiple syntax
+// errors instead of aborting on the first, inserting Bad{Definition, Field,
+// Value, Type} placeholder nodes where it had to resynchronize. The returned
+// error is a [ParseErrors] aggregating every error found; the [ast.Document]
+// is still populated with whatever was parsed successfully.
+//
+// When this option is not set, the parser fails fast on the first syntax
+// error and the conformance corpus runs in this default mode.
+func WithRecovery() Option {
+	return func(c *config) { c.recovery = true }
 }
 
 func newConfig(opts []Option) *config {

--- a/parser/options.go
+++ b/parser/options.go
@@ -1,0 +1,22 @@
+package parser
+
+// Option configures a parse operation. Future additions (e.g. WithRecovery,
+// WithComments, WithExperimental) will land here without API churn —
+// every Parse* entry point already accepts variadic options.
+type Option func(*config)
+
+type config struct {
+	// recovery and preserveComments will be wired up by phases 11 and 12.
+	recovery         bool
+	preserveComments bool
+}
+
+func newConfig(opts []Option) *config {
+	cfg := &config{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(cfg)
+		}
+	}
+	return cfg
+}

--- a/parser/options.go
+++ b/parser/options.go
@@ -22,6 +22,19 @@ func WithRecovery() Option {
 	return func(c *config) { c.recovery = true }
 }
 
+// WithComments enables comment preservation. When set, the parser collects
+// '#' comments and attaches them as Leading trivia on the next AST node it
+// produces — at top-level Definitions and inside type-system definition
+// bodies (field, enum-value, and input-value definitions). The
+// Comments field on every AST node is otherwise nil.
+//
+// Trailing comments and value/type-level comments are not yet attributed;
+// callers needing the full comment stream can read raw COMMENT tokens
+// directly from a [lexer.Lexer] with PreserveComments=true.
+func WithComments() Option {
+	return func(c *config) { c.preserveComments = true }
+}
+
 func newConfig(opts []Option) *config {
 	cfg := &config{}
 	for _, opt := range opts {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -8,8 +8,8 @@ package parser
 import (
 	"fmt"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // parser is the internal recursive-descent driver. It is not safe for

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -19,6 +19,7 @@ type parser struct {
 	lex     *lexer.Lexer
 	cfg     *config
 	lastEnd int // byte offset just past the last consumed token
+	errors  []*ast.SyntaxError
 }
 
 func newParser(src *ast.Source, opts []Option) *parser {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -15,11 +15,12 @@ import (
 // parser is the internal recursive-descent driver. It is not safe for
 // concurrent use.
 type parser struct {
-	source  *ast.Source
-	lex     *lexer.Lexer
-	cfg     *config
-	lastEnd int // byte offset just past the last consumed token
-	errors  []*ast.SyntaxError
+	source         *ast.Source
+	lex            *lexer.Lexer
+	cfg            *config
+	lastEnd        int // byte offset just past the last consumed token
+	errors         []*ast.SyntaxError
+	pendingLeading []*ast.Comment
 }
 
 func newParser(src *ast.Source, opts []Option) *parser {
@@ -31,13 +32,17 @@ func newParser(src *ast.Source, opts []Option) *parser {
 	return &parser{source: src, lex: l, cfg: cfg}
 }
 
-// peek returns the next token without consuming it.
+// peek returns the next non-comment token without consuming it. When
+// comment preservation is on, any COMMENT tokens at the current position
+// are drained into p.pendingLeading first.
 func (p *parser) peek() (lexer.Token, error) {
+	p.drainComments()
 	return p.lex.Peek()
 }
 
-// advance consumes and returns the next token, updating lastEnd.
+// advance consumes and returns the next non-comment token, updating lastEnd.
 func (p *parser) advance() (lexer.Token, error) {
+	p.drainComments()
 	tok, err := p.lex.Next()
 	if err != nil {
 		return tok, err

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,0 +1,146 @@
+// Package parser converts GraphQL source text into an [ast.Document] (or, via
+// partial entry points, a single [ast.Value] or [ast.Type]). Errors are
+// returned as [ParseError]; in fail-fast mode the first syntax error aborts
+// the parse. Recovery mode, comments, and experimental-feature flags are
+// configured via [Option] values.
+package parser
+
+import (
+	"fmt"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+// parser is the internal recursive-descent driver. It is not safe for
+// concurrent use.
+type parser struct {
+	source  *ast.Source
+	lex     *lexer.Lexer
+	cfg     *config
+	lastEnd int // byte offset just past the last consumed token
+}
+
+func newParser(src *ast.Source, opts []Option) *parser {
+	cfg := newConfig(opts)
+	l := lexer.New(src)
+	if cfg.preserveComments {
+		l.PreserveComments = true
+	}
+	return &parser{source: src, lex: l, cfg: cfg}
+}
+
+// peek returns the next token without consuming it.
+func (p *parser) peek() (lexer.Token, error) {
+	return p.lex.Peek()
+}
+
+// advance consumes and returns the next token, updating lastEnd.
+func (p *parser) advance() (lexer.Token, error) {
+	tok, err := p.lex.Next()
+	if err != nil {
+		return tok, err
+	}
+	p.lastEnd = tok.End
+	return tok, nil
+}
+
+// expect consumes the next token, returning an error if its kind is not k.
+func (p *parser) expect(k lexer.Kind) (lexer.Token, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return tok, err
+	}
+	if tok.Kind != k {
+		return tok, p.errAtTok(tok, fmt.Sprintf("Expected %s, found %s.", k, describeToken(tok)))
+	}
+	return p.advance()
+}
+
+// optional consumes the next token if it has kind k and returns whether it did.
+func (p *parser) optional(k lexer.Kind) (lexer.Token, bool, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return tok, false, err
+	}
+	if tok.Kind != k {
+		return tok, false, nil
+	}
+	got, err := p.advance()
+	return got, err == nil, err
+}
+
+// expectKeyword consumes the next token and verifies it is a NAME token whose
+// value equals kw. This is how the grammar dispatches on identifiers like
+// "query", "type", "on", etc.
+func (p *parser) expectKeyword(kw string) (lexer.Token, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return tok, err
+	}
+	if tok.Kind != lexer.NAME || tok.Value != kw {
+		return tok, p.errAtTok(tok, fmt.Sprintf("Expected %q, found %s.", kw, describeToken(tok)))
+	}
+	return p.advance()
+}
+
+// optionalKeyword consumes a NAME token equal to kw and returns whether it did.
+func (p *parser) optionalKeyword(kw string) (bool, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return false, err
+	}
+	if tok.Kind != lexer.NAME || tok.Value != kw {
+		return false, nil
+	}
+	if _, err := p.advance(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// expectEOF errors if the next token is not EOF — used to validate that a
+// partial-parse entry point (ParseValue, ParseType) consumed the entire input.
+func (p *parser) expectEOF() error {
+	tok, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if tok.Kind != lexer.EOF {
+		return p.errAtTok(tok, fmt.Sprintf("Expected <EOF>, found %s.", describeToken(tok)))
+	}
+	return nil
+}
+
+// loc constructs an *ast.Loc covering [start, p.lastEnd).
+func (p *parser) loc(start int) *ast.Loc {
+	return &ast.Loc{Start: start, End: p.lastEnd, Source: p.source}
+}
+
+// errAtTok builds a SyntaxError pointing at a specific token.
+func (p *parser) errAtTok(tok lexer.Token, msg string) *ast.SyntaxError {
+	return &ast.SyntaxError{Source: p.source, Offset: tok.Start, Message: msg}
+}
+
+// describeToken renders a token for error messages.
+func describeToken(tok lexer.Token) string {
+	switch tok.Kind {
+	case lexer.EOF:
+		return "<EOF>"
+	case lexer.NAME:
+		return fmt.Sprintf("Name %q", tok.Value)
+	case lexer.INT:
+		return fmt.Sprintf("Int %q", tok.Value)
+	case lexer.FLOAT:
+		return fmt.Sprintf("Float %q", tok.Value)
+	case lexer.STRING:
+		if tok.Block {
+			return "BlockString"
+		}
+		return "String"
+	case lexer.COMMENT:
+		return "Comment"
+	default:
+		return tok.Kind.String()
+	}
+}

--- a/parser/recover.go
+++ b/parser/recover.go
@@ -1,0 +1,99 @@
+package parser
+
+import (
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+// definitionStartKeywords names every keyword that may begin a top-level
+// Definition (executable + type-system, plus extensions).
+var definitionStartKeywords = map[string]struct{}{
+	"query": {}, "mutation": {}, "subscription": {}, "fragment": {},
+	"schema": {}, "scalar": {}, "type": {}, "interface": {},
+	"union": {}, "enum": {}, "input": {}, "directive": {}, "extend": {},
+}
+
+// isDefinitionStart reports whether tok could begin a Definition.
+func isDefinitionStart(tok lexer.Token) bool {
+	switch tok.Kind {
+	case lexer.LBRACE: // shorthand operation
+		return true
+	case lexer.STRING: // leading description
+		return true
+	case lexer.NAME:
+		_, ok := definitionStartKeywords[tok.Value]
+		return ok
+	}
+	return false
+}
+
+// recordError accumulates err into p.errors. It returns true when recovery
+// is enabled (caller may continue with a Bad* placeholder); false otherwise.
+func (p *parser) recordError(err error) bool {
+	if !p.cfg.recovery {
+		return false
+	}
+	se, ok := err.(*ast.SyntaxError)
+	if !ok {
+		return false
+	}
+	p.errors = append(p.errors, se)
+	return true
+}
+
+// skipToDefinitionStart advances past tokens until the next one could begin
+// a Definition (or EOF). Used by recovery to resync after a malformed
+// top-level definition.
+func (p *parser) skipToDefinitionStart() {
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			// Lexer error: try to consume one byte by attempting to advance.
+			// If advance still errors, accumulate and stop.
+			if !p.recordError(err) {
+				return
+			}
+			if _, err2 := p.advance(); err2 != nil {
+				_ = p.recordError(err2)
+				return
+			}
+			continue
+		}
+		if tok.Kind == lexer.EOF {
+			return
+		}
+		if isDefinitionStart(tok) {
+			return
+		}
+		if _, err := p.advance(); err != nil {
+			_ = p.recordError(err)
+			return
+		}
+	}
+}
+
+// skipToSelectionStart advances past tokens until the next one could begin
+// a Selection (or "}" / EOF). Used by recovery inside a SelectionSet.
+func (p *parser) skipToSelectionStart() {
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			if !p.recordError(err) {
+				return
+			}
+			if _, err2 := p.advance(); err2 != nil {
+				_ = p.recordError(err2)
+				return
+			}
+			continue
+		}
+		if tok.Kind == lexer.EOF || tok.Kind == lexer.RBRACE ||
+			tok.Kind == lexer.NAME || tok.Kind == lexer.SPREAD {
+			return
+		}
+		if _, err := p.advance(); err != nil {
+			_ = p.recordError(err)
+			return
+		}
+	}
+}

--- a/parser/recover.go
+++ b/parser/recover.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // definitionStartKeywords names every keyword that may begin a top-level

--- a/parser/recover_test.go
+++ b/parser/recover_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 func TestRecovery_Off_StillFailsFast(t *testing.T) {

--- a/parser/recover_test.go
+++ b/parser/recover_test.go
@@ -1,0 +1,168 @@
+package parser_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+func TestRecovery_Off_StillFailsFast(t *testing.T) {
+	// Identical to phase 6's empty-document test: with no WithRecovery the
+	// API behaves exactly as before.
+	if _, err := parser.Parse(""); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := parser.Parse("{ foo bar(}"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRecovery_BadDefinition_ResumesAtNextDefinition(t *testing.T) {
+	body := `
+		bogus_keyword stuff
+		query Q { ok }
+	`
+	doc, err := parser.Parse(body, parser.WithRecovery())
+	if err == nil {
+		t.Fatal("expected ParseErrors")
+	}
+	var es parser.ParseErrors
+	if !errors.As(err, &es) {
+		t.Fatalf("err is %T, expected ParseErrors", err)
+	}
+	if len(es) == 0 {
+		t.Errorf("expected at least 1 error, got %d", len(es))
+	}
+	if doc == nil {
+		t.Fatal("expected partial document")
+	}
+	if len(doc.Definitions) < 2 {
+		t.Fatalf("expected >=2 definitions; got %d (%v)", len(doc.Definitions), doc.Definitions)
+	}
+	if _, ok := doc.Definitions[0].(*ast.BadDefinition); !ok {
+		t.Errorf("[0] is %T; want BadDefinition", doc.Definitions[0])
+	}
+	if op, ok := doc.Definitions[1].(*ast.OperationDefinition); !ok || op.Name != "Q" {
+		t.Errorf("[1] is %T %v; want OperationDefinition Q", doc.Definitions[1], doc.Definitions[1])
+	}
+}
+
+func TestRecovery_MultipleBadDefinitions(t *testing.T) {
+	// "bogus1 bogus2" coalesces into a single BadDefinition because
+	// skipToDefinitionStart advances over consecutive non-keyword tokens
+	// until it lands on a real definition keyword. That is intentional
+	// (less noise for the LSP); the contract we test is "the good defs
+	// survive and at least one error is reported per bad region."
+	body := `
+		bogus1 bogus2
+		query Q { ok }
+		more_bogus
+		fragment F on T { y }
+	`
+	doc, err := parser.Parse(body, parser.WithRecovery())
+	var es parser.ParseErrors
+	if !errors.As(err, &es) {
+		t.Fatalf("err is %T", err)
+	}
+	if len(es) < 2 {
+		t.Errorf("expected >=2 errors, got %d: %v", len(es), es)
+	}
+
+	bad, good := 0, 0
+	for _, def := range doc.Definitions {
+		if _, ok := def.(*ast.BadDefinition); ok {
+			bad++
+		} else {
+			good++
+		}
+	}
+	if bad < 2 || good < 2 {
+		t.Errorf("expected >=2 bad and >=2 good defs; got bad=%d good=%d", bad, good)
+	}
+}
+
+func TestRecovery_BadFieldInsideSelectionSet(t *testing.T) {
+	// "{ a $bogus b }" — $ is not a legal selection start. Recovery skips
+	// it as a single bad token, then "bogus" parses as a fresh Field. The
+	// contract: good fields a and b survive, at least one BadField is
+	// inserted, and recovery reports the error.
+	body := `{ a $bogus b }`
+	doc, err := parser.Parse(body, parser.WithRecovery())
+	var es parser.ParseErrors
+	if !errors.As(err, &es) {
+		t.Fatalf("err is %T (want ParseErrors): %v", err, err)
+	}
+	if len(es) == 0 {
+		t.Error("expected at least 1 error")
+	}
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	if op.SelectionSet == nil {
+		t.Fatal("nil selection set")
+	}
+	sels := op.SelectionSet.Selections
+	if len(sels) < 3 {
+		t.Fatalf("selections = %d; want >=3", len(sels))
+	}
+
+	var hasA, hasB, hasBad bool
+	for _, s := range sels {
+		switch v := s.(type) {
+		case *ast.Field:
+			if v.Name == "a" {
+				hasA = true
+			}
+			if v.Name == "b" {
+				hasB = true
+			}
+		case *ast.BadField:
+			hasBad = true
+		}
+	}
+	if !hasA || !hasB {
+		t.Errorf("expected both 'a' and 'b' to survive; hasA=%v hasB=%v", hasA, hasB)
+	}
+	if !hasBad {
+		t.Error("expected at least one BadField placeholder")
+	}
+}
+
+func TestRecovery_ErrorsCarryPositions(t *testing.T) {
+	body := `bogus query Q { ok }`
+	_, err := parser.Parse(body, parser.WithRecovery())
+	var es parser.ParseErrors
+	if !errors.As(err, &es) {
+		t.Fatalf("err is %T", err)
+	}
+	if len(es) == 0 {
+		t.Fatal("no errors")
+	}
+	pos := es[0].Position()
+	if pos.Line != 1 || pos.Column < 1 {
+		t.Errorf("error position = %+v; expected line 1, column >=1", pos)
+	}
+}
+
+func TestRecovery_NoErrors_NoParseErrors(t *testing.T) {
+	body := `query Q { x }`
+	doc, err := parser.Parse(body, parser.WithRecovery())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected document")
+	}
+}
+
+func TestRecovery_ErrorMessage_AggregatesAll(t *testing.T) {
+	body := `bogus1 bogus2`
+	_, err := parser.Parse(body, parser.WithRecovery())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if len(msg) == 0 {
+		t.Error("error message empty")
+	}
+}

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -1,15 +1,947 @@
 package parser
 
-import "github.com/bellbm/graphql-parser/ast"
+import (
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
 
-// parseTypeSystemDefinitionOrExtension is a stub placeholder for phase 7,
-// which will implement the schema/SDL grammar. For now it simply reports
-// "no match" so the executable-document parser can fall through to its
-// own error path.
-//
-// The boolean return is true when the parser recognized a type-system
-// definition or extension and produced a Definition; false means the
-// caller's dispatch should report a "definition not recognized" error.
+// directiveLocations is the set of valid directive-location names per the
+// October 2021 spec.
+var directiveLocations = map[string]struct{}{
+	// Executable
+	"QUERY": {}, "MUTATION": {}, "SUBSCRIPTION": {}, "FIELD": {},
+	"FRAGMENT_DEFINITION": {}, "FRAGMENT_SPREAD": {}, "INLINE_FRAGMENT": {},
+	"VARIABLE_DEFINITION": {},
+	// Type system
+	"SCHEMA": {}, "SCALAR": {}, "OBJECT": {}, "FIELD_DEFINITION": {},
+	"ARGUMENT_DEFINITION": {}, "INTERFACE": {}, "UNION": {}, "ENUM": {},
+	"ENUM_VALUE": {}, "INPUT_OBJECT": {}, "INPUT_FIELD_DEFINITION": {},
+}
+
+// parseTypeSystemDefinitionOrExtension parses any of the type-system grammar
+// productions (schema/scalar/type/interface/union/enum/input/directive
+// definitions, plus their "extend" variants). It returns ok=false when the
+// next token does not begin one of these productions, in which case the
+// caller's dispatch should report an error.
 func (p *parser) parseTypeSystemDefinitionOrExtension() (ast.Definition, bool, error) {
+	// Optional leading description.
+	var desc *ast.StringValue
+	tok, err := p.peek()
+	if err != nil {
+		return nil, false, err
+	}
+	descStart := tok.Start
+	if tok.Kind == lexer.STRING {
+		strTok, err := p.advance()
+		if err != nil {
+			return nil, false, err
+		}
+		desc = &ast.StringValue{
+			Value: strTok.Value,
+			Block: strTok.Block,
+			Loc:   p.loc(strTok.Start),
+		}
+		tok, err = p.peek()
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	if tok.Kind != lexer.NAME {
+		if desc != nil {
+			return nil, false, p.errAtTok(tok, "Expected type-system definition keyword after description, found "+describeToken(tok)+".")
+		}
+		return nil, false, nil
+	}
+
+	switch tok.Value {
+	case "schema":
+		return p.parseSchemaDefinition(desc, descStart)
+	case "scalar":
+		return p.parseScalarTypeDefinition(desc, descStart)
+	case "type":
+		return p.parseObjectTypeDefinition(desc, descStart)
+	case "interface":
+		return p.parseInterfaceTypeDefinition(desc, descStart)
+	case "union":
+		return p.parseUnionTypeDefinition(desc, descStart)
+	case "enum":
+		return p.parseEnumTypeDefinition(desc, descStart)
+	case "input":
+		return p.parseInputObjectTypeDefinition(desc, descStart)
+	case "directive":
+		return p.parseDirectiveDefinition(desc, descStart)
+	case "extend":
+		if desc != nil {
+			return nil, false, p.errAtTok(tok, "Type extensions cannot have a description.")
+		}
+		return p.parseTypeSystemExtension()
+	}
+
+	if desc != nil {
+		return nil, false, p.errAtTok(tok, "Unexpected Name "+describeToken(tok)+".")
+	}
 	return nil, false, nil
+}
+
+// definitionStart returns whichever of the two starts is non-zero, preferring
+// the description start when present.
+func definitionStart(descStart, kwStart int, hasDesc bool) int {
+	if hasDesc {
+		return descStart
+	}
+	return kwStart
+}
+
+func (p *parser) parseSchemaDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("schema")
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	ots, err := p.parseOperationTypeDefinitions()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.SchemaDefinition{
+		Description:    desc,
+		Directives:     dirs,
+		OperationTypes: ots,
+		Loc:            p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+	}, true, nil
+}
+
+func (p *parser) parseOperationTypeDefinitions() ([]*ast.OperationTypeDefinition, error) {
+	if _, err := p.expect(lexer.LBRACE); err != nil {
+		return nil, err
+	}
+	var out []*ast.OperationTypeDefinition
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RBRACE {
+			break
+		}
+		ot, err := p.parseOperationTypeDefinition()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ot)
+	}
+	if _, err := p.expect(lexer.RBRACE); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected operation type definition.")
+	}
+	return out, nil
+}
+
+func (p *parser) parseOperationTypeDefinition() (*ast.OperationTypeDefinition, error) {
+	op, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	switch op.Value {
+	case "query", "mutation", "subscription":
+	default:
+		return nil, p.errAtTok(op, "Expected query, mutation, or subscription, found Name "+op.Value+".")
+	}
+	if _, err := p.expect(lexer.COLON); err != nil {
+		return nil, err
+	}
+	t, err := p.parseNamedType()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.OperationTypeDefinition{
+		Operation: ast.OperationType(op.Value),
+		Type:      t,
+		Loc:       p.loc(op.Start),
+	}, nil
+}
+
+func (p *parser) parseScalarTypeDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("scalar")
+	if err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.ScalarTypeDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Directives:  dirs,
+		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+	}, true, nil
+}
+
+func (p *parser) parseObjectTypeDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("type")
+	if err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	ifaces, err := p.parseImplementsInterfaces()
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	fields, err := p.parseFieldsDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.ObjectTypeDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Interfaces:  ifaces,
+		Directives:  dirs,
+		Fields:      fields,
+		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+	}, true, nil
+}
+
+func (p *parser) parseInterfaceTypeDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("interface")
+	if err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	ifaces, err := p.parseImplementsInterfaces()
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	fields, err := p.parseFieldsDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.InterfaceTypeDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Interfaces:  ifaces,
+		Directives:  dirs,
+		Fields:      fields,
+		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+	}, true, nil
+}
+
+func (p *parser) parseImplementsInterfaces() ([]*ast.NamedType, error) {
+	ok, err := p.optionalKeyword("implements")
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	// Optional leading "&" per spec.
+	if _, _, err := p.optional(lexer.AMP); err != nil {
+		return nil, err
+	}
+	var out []*ast.NamedType
+	for {
+		t, err := p.parseNamedType()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+		_, ok, err := p.optional(lexer.AMP)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (p *parser) parseFieldsDefinition() (ast.FieldDefinitionList, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	if tok.Kind != lexer.LBRACE {
+		return nil, nil
+	}
+	if _, err := p.advance(); err != nil {
+		return nil, err
+	}
+	var out ast.FieldDefinitionList
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RBRACE {
+			break
+		}
+		f, err := p.parseFieldDefinition()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	if _, err := p.expect(lexer.RBRACE); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected field definition.")
+	}
+	return out, nil
+}
+
+func (p *parser) parseFieldDefinition() (*ast.FieldDefinition, error) {
+	desc, descStart, err := p.parseOptionalDescription()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	args, err := p.parseArgumentsDefinition()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(lexer.COLON); err != nil {
+		return nil, err
+	}
+	t, err := p.parseTypeReference()
+	if err != nil {
+		return nil, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, err
+	}
+	start := descStart
+	if desc == nil {
+		start = name.Start
+	}
+	return &ast.FieldDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Arguments:   args,
+		Type:        t,
+		Directives:  dirs,
+		Loc:         p.loc(start),
+	}, nil
+}
+
+func (p *parser) parseArgumentsDefinition() (ast.InputValueList, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	if tok.Kind != lexer.LPAREN {
+		return nil, nil
+	}
+	if _, err := p.advance(); err != nil {
+		return nil, err
+	}
+	var out ast.InputValueList
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RPAREN {
+			break
+		}
+		v, err := p.parseInputValueDefinition()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	if _, err := p.expect(lexer.RPAREN); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected argument definition.")
+	}
+	return out, nil
+}
+
+func (p *parser) parseInputValueDefinition() (*ast.InputValueDefinition, error) {
+	desc, descStart, err := p.parseOptionalDescription()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(lexer.COLON); err != nil {
+		return nil, err
+	}
+	t, err := p.parseTypeReference()
+	if err != nil {
+		return nil, err
+	}
+	var def ast.Value
+	if _, ok, err := p.optional(lexer.EQUALS); err != nil {
+		return nil, err
+	} else if ok {
+		v, err := p.parseValueLiteral(true)
+		if err != nil {
+			return nil, err
+		}
+		def = v
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, err
+	}
+	start := descStart
+	if desc == nil {
+		start = name.Start
+	}
+	return &ast.InputValueDefinition{
+		Description:  desc,
+		Name:         name.Value,
+		Type:         t,
+		DefaultValue: def,
+		Directives:   dirs,
+		Loc:          p.loc(start),
+	}, nil
+}
+
+func (p *parser) parseUnionTypeDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("union")
+	if err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	members, err := p.parseUnionMemberTypes()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.UnionTypeDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Directives:  dirs,
+		Members:     members,
+		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+	}, true, nil
+}
+
+func (p *parser) parseUnionMemberTypes() ([]*ast.NamedType, error) {
+	if _, ok, err := p.optional(lexer.EQUALS); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, nil
+	}
+	if _, _, err := p.optional(lexer.PIPE); err != nil {
+		return nil, err
+	}
+	var out []*ast.NamedType
+	for {
+		t, err := p.parseNamedType()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+		_, ok, err := p.optional(lexer.PIPE)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (p *parser) parseEnumTypeDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("enum")
+	if err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	values, err := p.parseEnumValuesDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.EnumTypeDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Directives:  dirs,
+		Values:      values,
+		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+	}, true, nil
+}
+
+func (p *parser) parseEnumValuesDefinition() (ast.EnumValueList, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	if tok.Kind != lexer.LBRACE {
+		return nil, nil
+	}
+	if _, err := p.advance(); err != nil {
+		return nil, err
+	}
+	var out ast.EnumValueList
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RBRACE {
+			break
+		}
+		v, err := p.parseEnumValueDefinition()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	if _, err := p.expect(lexer.RBRACE); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected enum value definition.")
+	}
+	return out, nil
+}
+
+func (p *parser) parseEnumValueDefinition() (*ast.EnumValueDefinition, error) {
+	desc, descStart, err := p.parseOptionalDescription()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	switch name.Value {
+	case "true", "false", "null":
+		return nil, p.errAtTok(name, "Enum value cannot be true, false, or null.")
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, err
+	}
+	start := descStart
+	if desc == nil {
+		start = name.Start
+	}
+	return &ast.EnumValueDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Directives:  dirs,
+		Loc:         p.loc(start),
+	}, nil
+}
+
+func (p *parser) parseInputObjectTypeDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("input")
+	if err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	fields, err := p.parseInputFieldsDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.InputObjectTypeDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Directives:  dirs,
+		Fields:      fields,
+		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+	}, true, nil
+}
+
+func (p *parser) parseInputFieldsDefinition() (ast.InputValueList, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	if tok.Kind != lexer.LBRACE {
+		return nil, nil
+	}
+	if _, err := p.advance(); err != nil {
+		return nil, err
+	}
+	var out ast.InputValueList
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RBRACE {
+			break
+		}
+		v, err := p.parseInputValueDefinition()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	if _, err := p.expect(lexer.RBRACE); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected input field definition.")
+	}
+	return out, nil
+}
+
+func (p *parser) parseDirectiveDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("directive")
+	if err != nil {
+		return nil, false, err
+	}
+	if _, err := p.expect(lexer.AT); err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	args, err := p.parseArgumentsDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	repeatable, err := p.optionalKeyword("repeatable")
+	if err != nil {
+		return nil, false, err
+	}
+	if _, err := p.expectKeyword("on"); err != nil {
+		return nil, false, err
+	}
+	locs, err := p.parseDirectiveLocations()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.DirectiveDefinition{
+		Description: desc,
+		Name:        name.Value,
+		Arguments:   args,
+		Repeatable:  repeatable,
+		Locations:   locs,
+		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+	}, true, nil
+}
+
+func (p *parser) parseDirectiveLocations() ([]string, error) {
+	if _, _, err := p.optional(lexer.PIPE); err != nil {
+		return nil, err
+	}
+	var out []string
+	for {
+		name, err := p.expect(lexer.NAME)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := directiveLocations[name.Value]; !ok {
+			return nil, p.errAtTok(name, "Unexpected directive location "+name.Value+".")
+		}
+		out = append(out, name.Value)
+		_, ok, err := p.optional(lexer.PIPE)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			break
+		}
+	}
+	return out, nil
+}
+
+// parseOptionalDescription consumes a leading StringValue (used as a
+// description) if present. Returns (nil, 0, nil) when the next token is not
+// a STRING.
+func (p *parser) parseOptionalDescription() (*ast.StringValue, int, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, 0, err
+	}
+	if tok.Kind != lexer.STRING {
+		return nil, 0, nil
+	}
+	str, err := p.advance()
+	if err != nil {
+		return nil, 0, err
+	}
+	return &ast.StringValue{
+		Value: str.Value,
+		Block: str.Block,
+		Loc:   p.loc(str.Start),
+	}, str.Start, nil
+}
+
+// parseTypeSystemExtension dispatches "extend ..." to the appropriate
+// extension-parser. The "extend" keyword has already been peeked.
+func (p *parser) parseTypeSystemExtension() (ast.Definition, bool, error) {
+	kw, err := p.expectKeyword("extend")
+	if err != nil {
+		return nil, false, err
+	}
+	tok, err := p.peek()
+	if err != nil {
+		return nil, false, err
+	}
+	if tok.Kind != lexer.NAME {
+		return nil, false, p.errAtTok(tok, "Expected type-system extension keyword, found "+describeToken(tok)+".")
+	}
+	switch tok.Value {
+	case "schema":
+		return p.parseSchemaExtension(kw.Start)
+	case "scalar":
+		return p.parseScalarTypeExtension(kw.Start)
+	case "type":
+		return p.parseObjectTypeExtension(kw.Start)
+	case "interface":
+		return p.parseInterfaceTypeExtension(kw.Start)
+	case "union":
+		return p.parseUnionTypeExtension(kw.Start)
+	case "enum":
+		return p.parseEnumTypeExtension(kw.Start)
+	case "input":
+		return p.parseInputObjectTypeExtension(kw.Start)
+	}
+	return nil, false, p.errAtTok(tok, "Unexpected extension target Name "+tok.Value+".")
+}
+
+func (p *parser) parseSchemaExtension(start int) (ast.Definition, bool, error) {
+	if _, err := p.expectKeyword("schema"); err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	var ots []*ast.OperationTypeDefinition
+	if tok, err := p.peek(); err != nil {
+		return nil, false, err
+	} else if tok.Kind == lexer.LBRACE {
+		ots, err = p.parseOperationTypeDefinitions()
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	if len(dirs) == 0 && len(ots) == 0 {
+		return nil, false, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Schema extension must define at least one directive or operation type.")
+	}
+	return &ast.SchemaExtension{
+		Directives:     dirs,
+		OperationTypes: ots,
+		Loc:            p.loc(start),
+	}, true, nil
+}
+
+func (p *parser) parseScalarTypeExtension(start int) (ast.Definition, bool, error) {
+	if _, err := p.expectKeyword("scalar"); err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(dirs) == 0 {
+		return nil, false, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Scalar extension must define at least one directive.")
+	}
+	return &ast.ScalarTypeExtension{
+		Name:       name.Value,
+		Directives: dirs,
+		Loc:        p.loc(start),
+	}, true, nil
+}
+
+func (p *parser) parseObjectTypeExtension(start int) (ast.Definition, bool, error) {
+	if _, err := p.expectKeyword("type"); err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	ifaces, err := p.parseImplementsInterfaces()
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	fields, err := p.parseFieldsDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(ifaces) == 0 && len(dirs) == 0 && len(fields) == 0 {
+		return nil, false, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Object extension must define at least one of: implements interfaces, directives, or fields.")
+	}
+	return &ast.ObjectTypeExtension{
+		Name:       name.Value,
+		Interfaces: ifaces,
+		Directives: dirs,
+		Fields:     fields,
+		Loc:        p.loc(start),
+	}, true, nil
+}
+
+func (p *parser) parseInterfaceTypeExtension(start int) (ast.Definition, bool, error) {
+	if _, err := p.expectKeyword("interface"); err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	ifaces, err := p.parseImplementsInterfaces()
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	fields, err := p.parseFieldsDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(ifaces) == 0 && len(dirs) == 0 && len(fields) == 0 {
+		return nil, false, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Interface extension must define at least one of: implements interfaces, directives, or fields.")
+	}
+	return &ast.InterfaceTypeExtension{
+		Name:       name.Value,
+		Interfaces: ifaces,
+		Directives: dirs,
+		Fields:     fields,
+		Loc:        p.loc(start),
+	}, true, nil
+}
+
+func (p *parser) parseUnionTypeExtension(start int) (ast.Definition, bool, error) {
+	if _, err := p.expectKeyword("union"); err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	members, err := p.parseUnionMemberTypes()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(dirs) == 0 && len(members) == 0 {
+		return nil, false, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Union extension must define at least one directive or member type.")
+	}
+	return &ast.UnionTypeExtension{
+		Name:       name.Value,
+		Directives: dirs,
+		Members:    members,
+		Loc:        p.loc(start),
+	}, true, nil
+}
+
+func (p *parser) parseEnumTypeExtension(start int) (ast.Definition, bool, error) {
+	if _, err := p.expectKeyword("enum"); err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	values, err := p.parseEnumValuesDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(dirs) == 0 && len(values) == 0 {
+		return nil, false, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Enum extension must define at least one directive or value.")
+	}
+	return &ast.EnumTypeExtension{
+		Name:       name.Value,
+		Directives: dirs,
+		Values:     values,
+		Loc:        p.loc(start),
+	}, true, nil
+}
+
+func (p *parser) parseInputObjectTypeExtension(start int) (ast.Definition, bool, error) {
+	if _, err := p.expectKeyword("input"); err != nil {
+		return nil, false, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, false, err
+	}
+	dirs, err := p.parseDirectives(true)
+	if err != nil {
+		return nil, false, err
+	}
+	fields, err := p.parseInputFieldsDefinition()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(dirs) == 0 && len(fields) == 0 {
+		return nil, false, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Input object extension must define at least one directive or field.")
+	}
+	return &ast.InputObjectTypeExtension{
+		Name:       name.Value,
+		Directives: dirs,
+		Fields:     fields,
+		Loc:        p.loc(start),
+	}, true, nil
 }

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -315,6 +315,8 @@ func (p *parser) parseFieldsDefinition() (ast.FieldDefinitionList, error) {
 }
 
 func (p *parser) parseFieldDefinition() (*ast.FieldDefinition, error) {
+	leading := p.pendingLeading
+	p.pendingLeading = nil
 	desc, descStart, err := p.parseOptionalDescription()
 	if err != nil {
 		return nil, err
@@ -342,14 +344,18 @@ func (p *parser) parseFieldDefinition() (*ast.FieldDefinition, error) {
 	if desc == nil {
 		start = name.Start
 	}
-	return &ast.FieldDefinition{
+	fd := &ast.FieldDefinition{
 		Description: desc,
 		Name:        name.Value,
 		Arguments:   args,
 		Type:        t,
 		Directives:  dirs,
 		Loc:         p.loc(start),
-	}, nil
+	}
+	if len(leading) > 0 {
+		fd.Comments = &ast.CommentGroup{Leading: leading}
+	}
+	return fd, nil
 }
 
 func (p *parser) parseArgumentsDefinition() (ast.InputValueList, error) {
@@ -388,6 +394,8 @@ func (p *parser) parseArgumentsDefinition() (ast.InputValueList, error) {
 }
 
 func (p *parser) parseInputValueDefinition() (*ast.InputValueDefinition, error) {
+	leading := p.pendingLeading
+	p.pendingLeading = nil
 	desc, descStart, err := p.parseOptionalDescription()
 	if err != nil {
 		return nil, err
@@ -421,14 +429,18 @@ func (p *parser) parseInputValueDefinition() (*ast.InputValueDefinition, error) 
 	if desc == nil {
 		start = name.Start
 	}
-	return &ast.InputValueDefinition{
+	iv := &ast.InputValueDefinition{
 		Description:  desc,
 		Name:         name.Value,
 		Type:         t,
 		DefaultValue: def,
 		Directives:   dirs,
 		Loc:          p.loc(start),
-	}, nil
+	}
+	if len(leading) > 0 {
+		iv.Comments = &ast.CommentGroup{Leading: leading}
+	}
+	return iv, nil
 }
 
 func (p *parser) parseUnionTypeDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {
@@ -546,6 +558,8 @@ func (p *parser) parseEnumValuesDefinition() (ast.EnumValueList, error) {
 }
 
 func (p *parser) parseEnumValueDefinition() (*ast.EnumValueDefinition, error) {
+	leading := p.pendingLeading
+	p.pendingLeading = nil
 	desc, descStart, err := p.parseOptionalDescription()
 	if err != nil {
 		return nil, err
@@ -566,12 +580,16 @@ func (p *parser) parseEnumValueDefinition() (*ast.EnumValueDefinition, error) {
 	if desc == nil {
 		start = name.Start
 	}
-	return &ast.EnumValueDefinition{
+	ev := &ast.EnumValueDefinition{
 		Description: desc,
 		Name:        name.Value,
 		Directives:  dirs,
 		Loc:         p.loc(start),
-	}, nil
+	}
+	if len(leading) > 0 {
+		ev.Comments = &ast.CommentGroup{Leading: leading}
+	}
+	return ev, nil
 }
 
 func (p *parser) parseInputObjectTypeDefinition(desc *ast.StringValue, descStart int) (ast.Definition, bool, error) {

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -1,0 +1,15 @@
+package parser
+
+import "github.com/bellbm/graphql-parser/ast"
+
+// parseTypeSystemDefinitionOrExtension is a stub placeholder for phase 7,
+// which will implement the schema/SDL grammar. For now it simply reports
+// "no match" so the executable-document parser can fall through to its
+// own error path.
+//
+// The boolean return is true when the parser recognized a type-system
+// definition or extension and produced a Definition; false means the
+// caller's dispatch should report a "definition not recognized" error.
+func (p *parser) parseTypeSystemDefinitionOrExtension() (ast.Definition, bool, error) {
+	return nil, false, nil
+}

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // directiveLocations is the set of valid directive-location names per the

--- a/parser/schema_test.go
+++ b/parser/schema_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 func TestParse_SchemaDefinition(t *testing.T) {

--- a/parser/schema_test.go
+++ b/parser/schema_test.go
@@ -1,0 +1,343 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+func TestParse_SchemaDefinition(t *testing.T) {
+	doc := mustParse(t, `schema { query: Query mutation: Mutation }`)
+	sd := doc.Definitions[0].(*ast.SchemaDefinition)
+	if len(sd.OperationTypes) != 2 {
+		t.Fatalf("ots = %d; want 2", len(sd.OperationTypes))
+	}
+	if sd.OperationTypes[0].Operation != ast.OperationQuery {
+		t.Errorf("op[0] = %q; want query", sd.OperationTypes[0].Operation)
+	}
+	if sd.OperationTypes[0].Type.Name != "Query" {
+		t.Errorf("op[0].Type = %q; want Query", sd.OperationTypes[0].Type.Name)
+	}
+}
+
+func TestParse_SchemaWithDescriptionAndDirectives(t *testing.T) {
+	body := `"the schema" schema @secured { query: Q }`
+	doc := mustParse(t, body)
+	sd := doc.Definitions[0].(*ast.SchemaDefinition)
+	if sd.Description == nil || sd.Description.Value != "the schema" {
+		t.Errorf("desc = %v", sd.Description)
+	}
+	if len(sd.Directives) != 1 || sd.Directives[0].Name != "secured" {
+		t.Errorf("directives = %v", sd.Directives)
+	}
+}
+
+func TestParse_ScalarType(t *testing.T) {
+	doc := mustParse(t, `scalar URL @specifiedBy(url: "https://example.com")`)
+	sd := doc.Definitions[0].(*ast.ScalarTypeDefinition)
+	if sd.Name != "URL" {
+		t.Errorf("name = %q; want URL", sd.Name)
+	}
+	if len(sd.Directives) != 1 {
+		t.Errorf("directives = %d; want 1", len(sd.Directives))
+	}
+}
+
+func TestParse_ObjectType(t *testing.T) {
+	body := `
+		"User account."
+		type User implements Node & HasName @auth(role: ADMIN) {
+			"the id"
+			id: ID!
+			name(format: NameFormat = LONG): String!
+			friends(first: Int): [User!]!
+		}`
+	doc := mustParse(t, body)
+	od := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	if od.Description == nil || od.Description.Value != "User account." {
+		t.Errorf("desc = %v", od.Description)
+	}
+	if od.Name != "User" {
+		t.Errorf("name = %q", od.Name)
+	}
+	if len(od.Interfaces) != 2 {
+		t.Errorf("interfaces = %d; want 2", len(od.Interfaces))
+	}
+	if od.Interfaces[0].Name != "Node" || od.Interfaces[1].Name != "HasName" {
+		t.Errorf("interfaces = %v", od.Interfaces)
+	}
+	if len(od.Directives) != 1 || od.Directives[0].Name != "auth" {
+		t.Errorf("directives = %v", od.Directives)
+	}
+	if len(od.Fields) != 3 {
+		t.Fatalf("fields = %d; want 3", len(od.Fields))
+	}
+	idField := od.Fields.ForName("id")
+	if idField == nil || idField.Description == nil || idField.Description.Value != "the id" {
+		t.Errorf("id field wrong: %+v", idField)
+	}
+	nameField := od.Fields.ForName("name")
+	if nameField == nil || len(nameField.Arguments) != 1 {
+		t.Errorf("name args = %v", nameField)
+	}
+	formatArg := nameField.Arguments.ForName("format")
+	if formatArg == nil || formatArg.DefaultValue == nil {
+		t.Errorf("format arg has no default: %v", formatArg)
+	}
+}
+
+func TestParse_ObjectType_LeadingAmpInImplements(t *testing.T) {
+	doc := mustParse(t, `type T implements & A & B { x: Int }`)
+	od := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	if len(od.Interfaces) != 2 {
+		t.Errorf("interfaces = %d; want 2", len(od.Interfaces))
+	}
+}
+
+func TestParse_InterfaceType(t *testing.T) {
+	doc := mustParse(t, `interface Node implements Identifiable { id: ID! }`)
+	id := doc.Definitions[0].(*ast.InterfaceTypeDefinition)
+	if id.Name != "Node" {
+		t.Errorf("name = %q", id.Name)
+	}
+	if len(id.Interfaces) != 1 || id.Interfaces[0].Name != "Identifiable" {
+		t.Errorf("interfaces = %v", id.Interfaces)
+	}
+}
+
+func TestParse_UnionType(t *testing.T) {
+	doc := mustParse(t, `union SearchResult = User | Post | Comment`)
+	ud := doc.Definitions[0].(*ast.UnionTypeDefinition)
+	if len(ud.Members) != 3 {
+		t.Errorf("members = %d; want 3", len(ud.Members))
+	}
+}
+
+func TestParse_UnionType_LeadingPipe(t *testing.T) {
+	doc := mustParse(t, `union U = | A | B`)
+	ud := doc.Definitions[0].(*ast.UnionTypeDefinition)
+	if len(ud.Members) != 2 {
+		t.Errorf("members = %d; want 2", len(ud.Members))
+	}
+}
+
+func TestParse_UnionType_NoMembers(t *testing.T) {
+	doc := mustParse(t, `union Empty`)
+	ud := doc.Definitions[0].(*ast.UnionTypeDefinition)
+	if len(ud.Members) != 0 {
+		t.Errorf("members = %d; want 0", len(ud.Members))
+	}
+}
+
+func TestParse_EnumType(t *testing.T) {
+	body := `
+		enum Color {
+			"the color of fire"
+			RED
+			GREEN
+			BLUE @deprecated(reason: "use INDIGO")
+		}`
+	doc := mustParse(t, body)
+	ed := doc.Definitions[0].(*ast.EnumTypeDefinition)
+	if len(ed.Values) != 3 {
+		t.Fatalf("values = %d; want 3", len(ed.Values))
+	}
+	if ed.Values.ForName("RED").Description.Value != "the color of fire" {
+		t.Error("RED desc wrong")
+	}
+	if len(ed.Values.ForName("BLUE").Directives) != 1 {
+		t.Error("BLUE has no directive")
+	}
+}
+
+func TestParse_EnumValueRejectsReserved(t *testing.T) {
+	for _, body := range []string{`enum E { true }`, `enum E { false }`, `enum E { null }`} {
+		if _, err := parser.Parse(body); err == nil {
+			t.Errorf("%q: expected error", body)
+		}
+	}
+}
+
+func TestParse_InputObjectType(t *testing.T) {
+	body := `input UserInput { name: String! age: Int = 18 @validate(min: 0) }`
+	doc := mustParse(t, body)
+	id := doc.Definitions[0].(*ast.InputObjectTypeDefinition)
+	if len(id.Fields) != 2 {
+		t.Fatalf("fields = %d; want 2", len(id.Fields))
+	}
+	age := id.Fields.ForName("age")
+	if age == nil || age.DefaultValue == nil {
+		t.Error("age field has no default")
+	}
+	if iv, ok := age.DefaultValue.(*ast.IntValue); !ok || iv.Value != "18" {
+		t.Errorf("age default = %v; want IntValue 18", age.DefaultValue)
+	}
+	if len(age.Directives) != 1 {
+		t.Errorf("age directives = %d; want 1", len(age.Directives))
+	}
+}
+
+func TestParse_DirectiveDefinition(t *testing.T) {
+	body := `directive @auth(role: Role!) on FIELD | OBJECT | FIELD_DEFINITION`
+	doc := mustParse(t, body)
+	dd := doc.Definitions[0].(*ast.DirectiveDefinition)
+	if dd.Name != "auth" {
+		t.Errorf("name = %q", dd.Name)
+	}
+	if len(dd.Arguments) != 1 {
+		t.Errorf("args = %d; want 1", len(dd.Arguments))
+	}
+	if dd.Repeatable {
+		t.Error("Repeatable = true; want false")
+	}
+	want := []string{"FIELD", "OBJECT", "FIELD_DEFINITION"}
+	if len(dd.Locations) != len(want) {
+		t.Fatalf("locations = %v; want %v", dd.Locations, want)
+	}
+	for i, w := range want {
+		if dd.Locations[i] != w {
+			t.Errorf("locations[%d] = %q; want %q", i, dd.Locations[i], w)
+		}
+	}
+}
+
+func TestParse_DirectiveDefinition_Repeatable(t *testing.T) {
+	doc := mustParse(t, `directive @tag(name: String!) repeatable on OBJECT`)
+	dd := doc.Definitions[0].(*ast.DirectiveDefinition)
+	if !dd.Repeatable {
+		t.Error("Repeatable = false; want true")
+	}
+}
+
+func TestParse_DirectiveDefinition_LeadingPipe(t *testing.T) {
+	doc := mustParse(t, `directive @x on | FIELD | OBJECT`)
+	dd := doc.Definitions[0].(*ast.DirectiveDefinition)
+	if len(dd.Locations) != 2 {
+		t.Errorf("locations = %d; want 2", len(dd.Locations))
+	}
+}
+
+func TestParse_DirectiveDefinition_RejectsBadLocation(t *testing.T) {
+	if _, err := parser.Parse(`directive @x on FROBNICATE`); err == nil {
+		t.Error("expected error for unknown directive location")
+	}
+}
+
+func TestParse_Extensions(t *testing.T) {
+	body := `
+		extend schema { mutation: Mutation }
+		extend scalar URL @new
+		extend type User { x: Int }
+		extend interface Node { y: Int }
+		extend union Result = Z
+		extend enum Color { ORANGE }
+		extend input UserInput { phone: String }`
+	doc := mustParse(t, body)
+	if len(doc.Definitions) != 7 {
+		t.Fatalf("defs = %d; want 7", len(doc.Definitions))
+	}
+	if _, ok := doc.Definitions[0].(*ast.SchemaExtension); !ok {
+		t.Error("[0] not SchemaExtension")
+	}
+	if _, ok := doc.Definitions[1].(*ast.ScalarTypeExtension); !ok {
+		t.Error("[1] not ScalarTypeExtension")
+	}
+	if _, ok := doc.Definitions[2].(*ast.ObjectTypeExtension); !ok {
+		t.Error("[2] not ObjectTypeExtension")
+	}
+	if _, ok := doc.Definitions[3].(*ast.InterfaceTypeExtension); !ok {
+		t.Error("[3] not InterfaceTypeExtension")
+	}
+	if _, ok := doc.Definitions[4].(*ast.UnionTypeExtension); !ok {
+		t.Error("[4] not UnionTypeExtension")
+	}
+	if _, ok := doc.Definitions[5].(*ast.EnumTypeExtension); !ok {
+		t.Error("[5] not EnumTypeExtension")
+	}
+	if _, ok := doc.Definitions[6].(*ast.InputObjectTypeExtension); !ok {
+		t.Error("[6] not InputObjectTypeExtension")
+	}
+}
+
+func TestParse_Extensions_RejectsLeadingDescription(t *testing.T) {
+	body := `"a description" extend type User { x: Int }`
+	_, err := parser.Parse(body)
+	if err == nil {
+		t.Fatal("expected error: extensions cannot have description")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "description") {
+		t.Errorf("error %q does not mention description", err.Error())
+	}
+}
+
+func TestParse_Extensions_RequireSomeContent(t *testing.T) {
+	cases := []string{
+		`extend schema`,
+		`extend scalar URL`,
+		`extend type User`,
+		`extend interface Node`,
+		`extend union U`,
+		`extend enum E`,
+		`extend input I`,
+	}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			if _, err := parser.Parse(body); err == nil {
+				t.Errorf("%q: expected error for empty extension", body)
+			}
+		})
+	}
+}
+
+func TestParse_DescriptionsRequiredOnDefinitions(t *testing.T) {
+	// Description as a block string is fine.
+	body := `"""multi-line description""" type T { x: Int }`
+	doc := mustParse(t, body)
+	od := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	if od.Description == nil || !od.Description.Block || od.Description.Value != "multi-line description" {
+		t.Errorf("desc wrong: %+v", od.Description)
+	}
+}
+
+func TestParse_DescriptionsAcceptedOnAllDefinitionKinds(t *testing.T) {
+	body := `
+		"a" schema { query: Q }
+		"b" scalar URL
+		"c" type T { f: Int }
+		"d" interface I { f: Int }
+		"e" union U = A
+		"f" enum E { A }
+		"g" input In { f: Int }
+		"h" directive @foo on FIELD`
+	doc := mustParse(t, body)
+	if len(doc.Definitions) != 8 {
+		t.Fatalf("defs = %d; want 8", len(doc.Definitions))
+	}
+}
+
+func TestParse_FieldDefinitionWithDescriptionAndArguments(t *testing.T) {
+	body := `
+		type T {
+			"the field" field(
+				"first arg" first: Int = 10
+				"second arg" second: String!
+			): Boolean! @auth
+		}`
+	doc := mustParse(t, body)
+	od := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	f := od.Fields.ForName("field")
+	if f == nil {
+		t.Fatal("missing 'field'")
+	}
+	if f.Description == nil || f.Description.Value != "the field" {
+		t.Errorf("field desc = %v", f.Description)
+	}
+	if len(f.Arguments) != 2 {
+		t.Fatalf("args = %d; want 2", len(f.Arguments))
+	}
+	if f.Arguments.ForName("first").Description.Value != "first arg" {
+		t.Error("first-arg description wrong")
+	}
+}

--- a/parser/selection.go
+++ b/parser/selection.go
@@ -16,6 +16,11 @@ func (p *parser) parseSelectionSet() (*ast.SelectionSet, error) {
 	for {
 		tok, err := p.peek()
 		if err != nil {
+			if p.cfg.recovery {
+				_ = p.recordError(err)
+				p.skipToSelectionStart()
+				continue
+			}
 			return nil, err
 		}
 		if tok.Kind == lexer.RBRACE {
@@ -24,9 +29,16 @@ func (p *parser) parseSelectionSet() (*ast.SelectionSet, error) {
 		if tok.Kind == lexer.EOF {
 			return nil, p.errAtTok(tok, "Expected '}', found <EOF>.")
 		}
+		selStart := tok.Start
 		s, err := p.parseSelection()
 		if err != nil {
-			return nil, err
+			if !p.recordError(err) {
+				return nil, err
+			}
+			se, _ := err.(*ast.SyntaxError)
+			p.skipToSelectionStart()
+			sels = append(sels, &ast.BadField{Err: se, Loc: p.loc(selStart)})
+			continue
 		}
 		sels = append(sels, s)
 	}

--- a/parser/selection.go
+++ b/parser/selection.go
@@ -1,0 +1,176 @@
+package parser
+
+import (
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+// parseSelectionSet parses "{ Selection+ }". An empty selection set is a
+// syntax error per spec.
+func (p *parser) parseSelectionSet() (*ast.SelectionSet, error) {
+	open, err := p.expect(lexer.LBRACE)
+	if err != nil {
+		return nil, err
+	}
+	var sels []ast.Selection
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RBRACE {
+			break
+		}
+		if tok.Kind == lexer.EOF {
+			return nil, p.errAtTok(tok, "Expected '}', found <EOF>.")
+		}
+		s, err := p.parseSelection()
+		if err != nil {
+			return nil, err
+		}
+		sels = append(sels, s)
+	}
+	if _, err := p.expect(lexer.RBRACE); err != nil {
+		return nil, err
+	}
+	if len(sels) == 0 {
+		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected at least one selection.")
+	}
+	return &ast.SelectionSet{Selections: sels, Loc: p.loc(open.Start)}, nil
+}
+
+func (p *parser) parseSelection() (ast.Selection, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	if tok.Kind == lexer.SPREAD {
+		return p.parseFragment()
+	}
+	return p.parseField()
+}
+
+// parseField parses "[Alias :] Name (Arguments)? @Directive...? SelectionSet?".
+func (p *parser) parseField() (*ast.Field, error) {
+	first, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	field := &ast.Field{}
+
+	// If the next token is a colon, the first NAME was an alias.
+	if next, err := p.peek(); err != nil {
+		return nil, err
+	} else if next.Kind == lexer.COLON {
+		if _, err := p.advance(); err != nil {
+			return nil, err
+		}
+		nameTok, err := p.expect(lexer.NAME)
+		if err != nil {
+			return nil, err
+		}
+		field.Alias = first.Value
+		field.Name = nameTok.Value
+	} else {
+		field.Name = first.Value
+	}
+
+	args, err := p.parseArguments(false)
+	if err != nil {
+		return nil, err
+	}
+	field.Arguments = args
+
+	dirs, err := p.parseDirectives(false)
+	if err != nil {
+		return nil, err
+	}
+	field.Directives = dirs
+
+	if next, err := p.peek(); err != nil {
+		return nil, err
+	} else if next.Kind == lexer.LBRACE {
+		set, err := p.parseSelectionSet()
+		if err != nil {
+			return nil, err
+		}
+		field.SelectionSet = set
+	}
+
+	field.Loc = p.loc(first.Start)
+	return field, nil
+}
+
+// parseFragment dispatches between a FragmentSpread and an InlineFragment
+// based on the token following "...".
+//
+//	"..." Name [not "on"] Directives?         → FragmentSpread
+//	"..." "on" NamedType Directives? Set      → InlineFragment with TypeCondition
+//	"..." Directives? SelectionSet            → InlineFragment without TypeCondition
+func (p *parser) parseFragment() (ast.Selection, error) {
+	spread, err := p.expect(lexer.SPREAD)
+	if err != nil {
+		return nil, err
+	}
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	// "...on" is always an InlineFragment with TypeCondition.
+	if tok.Kind == lexer.NAME && tok.Value == "on" {
+		if _, err := p.advance(); err != nil {
+			return nil, err
+		}
+		cond, err := p.parseNamedType()
+		if err != nil {
+			return nil, err
+		}
+		dirs, err := p.parseDirectives(false)
+		if err != nil {
+			return nil, err
+		}
+		set, err := p.parseSelectionSet()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.InlineFragment{
+			TypeCondition: cond,
+			Directives:    dirs,
+			SelectionSet:  set,
+			Loc:           p.loc(spread.Start),
+		}, nil
+	}
+	// "...Name" is a FragmentSpread (Name is not "on").
+	if tok.Kind == lexer.NAME {
+		name, err := p.advance()
+		if err != nil {
+			return nil, err
+		}
+		dirs, err := p.parseDirectives(false)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.FragmentSpread{
+			Name:       name.Value,
+			Directives: dirs,
+			Loc:        p.loc(spread.Start),
+		}, nil
+	}
+	// "...@dir { ... }" or "...{ ... }" is an InlineFragment without TypeCondition.
+	if tok.Kind == lexer.AT || tok.Kind == lexer.LBRACE {
+		dirs, err := p.parseDirectives(false)
+		if err != nil {
+			return nil, err
+		}
+		set, err := p.parseSelectionSet()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.InlineFragment{
+			Directives:   dirs,
+			SelectionSet: set,
+			Loc:          p.loc(spread.Start),
+		}, nil
+	}
+	return nil, p.errAtTok(tok, "Expected fragment spread or inline fragment, found "+describeToken(tok)+".")
+}

--- a/parser/selection.go
+++ b/parser/selection.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // parseSelectionSet parses "{ Selection+ }". An empty selection set is a

--- a/parser/testdata/fuzz/FuzzParseWithRecovery/ed853cd85118209a
+++ b/parser/testdata/fuzz/FuzzParseWithRecovery/ed853cd85118209a
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0%")

--- a/parser/testdata/graphql-js/README.md
+++ b/parser/testdata/graphql-js/README.md
@@ -1,0 +1,40 @@
+# graphql-js parser-conformance corpus
+
+Test fixtures ported from [graphql/graphql-js](https://github.com/graphql/graphql-js)
+under its MIT license (see `THIRD_PARTY_LICENSES.md` at the repo root). The
+upstream files this corpus draws from:
+
+- `src/language/__tests__/lexer-test.ts`
+- `src/language/__tests__/parser-test.ts`
+- `src/language/__tests__/schema-parser-test.ts`
+- `src/language/__tests__/printer-test.ts` (printer-independent input cases)
+
+This directory holds the Go-side test driver in `corpus_test.go` plus
+optional `*.graphql` and `*.error` fixtures for cases where embedding the
+input as a string literal is awkward.
+
+## Adding a case
+
+Most cases live as table entries in `corpus_test.go`. To add one:
+
+1. Open `corpus_test.go`.
+2. Find the table that matches the kind of test (`parserCases`,
+   `lexerCases`, `schemaCases`, or `errorCases`).
+3. Add an entry with the upstream test name, input, and expectation.
+
+For inputs that contain awkward escape sequences or large blocks, drop a
+`.graphql` file in this directory and reference it by filename in the
+table.
+
+## Conformance bar
+
+In default fail-fast mode, the parser must:
+
+- Accept every input the upstream `graphql-js` parser accepts.
+- Reject every input the upstream rejects, with a `Syntax Error` whose
+  position matches upstream byte-for-byte.
+
+Error-message text is matched by substring on the relevant phrase; the
+graphql-js-style snippet rendering produces the same multi-line format
+but small wording differences are tolerated as long as the position is
+correct.

--- a/parser/type.go
+++ b/parser/type.go
@@ -1,0 +1,55 @@
+package parser
+
+import (
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+// parseTypeReference parses a Type:
+//
+//	Type: NamedType | ListType | NonNullType
+//	NamedType: Name
+//	ListType: [ Type ]
+//	NonNullType: NamedType ! | ListType !
+//
+// NonNull is a postfix operator that may apply to either of the inner forms,
+// but never to itself (Int!! is rejected).
+func (p *parser) parseTypeReference() (ast.Type, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	var inner ast.Type
+	switch tok.Kind {
+	case lexer.LBRACKET:
+		open, err := p.advance()
+		if err != nil {
+			return nil, err
+		}
+		of, err := p.parseTypeReference()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(lexer.RBRACKET); err != nil {
+			return nil, err
+		}
+		inner = &ast.ListType{OfType: of, Loc: p.loc(open.Start)}
+	case lexer.NAME:
+		name, err := p.advance()
+		if err != nil {
+			return nil, err
+		}
+		inner = &ast.NamedType{Name: name.Value, Loc: p.loc(name.Start)}
+	default:
+		return nil, p.errAtTok(tok, "Expected type, found "+describeToken(tok)+".")
+	}
+	// Optional trailing "!".
+	_, ok, err := p.optional(lexer.BANG)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return &ast.NonNullType{OfType: inner, Loc: p.loc(inner.GetLoc().Start)}, nil
+	}
+	return inner, nil
+}

--- a/parser/type.go
+++ b/parser/type.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // parseTypeReference parses a Type:

--- a/parser/value.go
+++ b/parser/value.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"fmt"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/lexer"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/lexer"
 )
 
 // parseValueLiteral parses a Value (or ConstValue when isConst is true).

--- a/parser/value.go
+++ b/parser/value.go
@@ -1,0 +1,151 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/lexer"
+)
+
+// parseValueLiteral parses a Value (or ConstValue when isConst is true).
+//
+//	Value: Variable | IntValue | FloatValue | StringValue | BooleanValue
+//	     | NullValue | EnumValue | ListValue | ObjectValue
+//
+// In a const context, Variable is rejected; otherwise it is allowed.
+func (p *parser) parseValueLiteral(isConst bool) (ast.Value, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	switch tok.Kind {
+	case lexer.LBRACKET:
+		return p.parseListValue(isConst)
+	case lexer.LBRACE:
+		return p.parseObjectValue(isConst)
+	case lexer.INT:
+		if _, err := p.advance(); err != nil {
+			return nil, err
+		}
+		return &ast.IntValue{Value: tok.Value, Loc: p.loc(tok.Start)}, nil
+	case lexer.FLOAT:
+		if _, err := p.advance(); err != nil {
+			return nil, err
+		}
+		return &ast.FloatValue{Value: tok.Value, Loc: p.loc(tok.Start)}, nil
+	case lexer.STRING:
+		if _, err := p.advance(); err != nil {
+			return nil, err
+		}
+		return &ast.StringValue{Value: tok.Value, Block: tok.Block, Loc: p.loc(tok.Start)}, nil
+	case lexer.NAME:
+		switch tok.Value {
+		case "true", "false":
+			if _, err := p.advance(); err != nil {
+				return nil, err
+			}
+			return &ast.BooleanValue{Value: tok.Value == "true", Loc: p.loc(tok.Start)}, nil
+		case "null":
+			if _, err := p.advance(); err != nil {
+				return nil, err
+			}
+			return &ast.NullValue{Loc: p.loc(tok.Start)}, nil
+		default:
+			if _, err := p.advance(); err != nil {
+				return nil, err
+			}
+			return &ast.EnumValue{Value: tok.Value, Loc: p.loc(tok.Start)}, nil
+		}
+	case lexer.DOLLAR:
+		if isConst {
+			return nil, p.errAtTok(tok, "Unexpected variable in const context.")
+		}
+		return p.parseVariable()
+	}
+	return nil, p.errAtTok(tok, fmt.Sprintf("Unexpected %s.", describeToken(tok)))
+}
+
+func (p *parser) parseVariable() (*ast.Variable, error) {
+	dollar, err := p.expect(lexer.DOLLAR)
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.Variable{Name: name.Value, Loc: p.loc(dollar.Start)}, nil
+}
+
+func (p *parser) parseListValue(isConst bool) (*ast.ListValue, error) {
+	open, err := p.expect(lexer.LBRACKET)
+	if err != nil {
+		return nil, err
+	}
+	var values []ast.Value
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RBRACKET {
+			break
+		}
+		if tok.Kind == lexer.EOF {
+			return nil, p.errAtTok(tok, "Expected ']', found <EOF>.")
+		}
+		v, err := p.parseValueLiteral(isConst)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, v)
+	}
+	if _, err := p.expect(lexer.RBRACKET); err != nil {
+		return nil, err
+	}
+	return &ast.ListValue{Values: values, Loc: p.loc(open.Start)}, nil
+}
+
+func (p *parser) parseObjectValue(isConst bool) (*ast.ObjectValue, error) {
+	open, err := p.expect(lexer.LBRACE)
+	if err != nil {
+		return nil, err
+	}
+	var fields []*ast.ObjectField
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.Kind == lexer.RBRACE {
+			break
+		}
+		if tok.Kind == lexer.EOF {
+			return nil, p.errAtTok(tok, "Expected '}', found <EOF>.")
+		}
+		f, err := p.parseObjectField(isConst)
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, f)
+	}
+	if _, err := p.expect(lexer.RBRACE); err != nil {
+		return nil, err
+	}
+	return &ast.ObjectValue{Fields: fields, Loc: p.loc(open.Start)}, nil
+}
+
+func (p *parser) parseObjectField(isConst bool) (*ast.ObjectField, error) {
+	name, err := p.expect(lexer.NAME)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(lexer.COLON); err != nil {
+		return nil, err
+	}
+	v, err := p.parseValueLiteral(isConst)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ObjectField{Name: name.Value, Value: v, Loc: p.loc(name.Start)}, nil
+}

--- a/parser/value_test.go
+++ b/parser/value_test.go
@@ -3,8 +3,8 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/bellbm/graphql-parser/ast"
-	"github.com/bellbm/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
 )
 
 func TestParseValue_Int(t *testing.T) {

--- a/parser/value_test.go
+++ b/parser/value_test.go
@@ -1,0 +1,371 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/bellbm/graphql-parser/ast"
+	"github.com/bellbm/graphql-parser/parser"
+)
+
+func TestParseValue_Int(t *testing.T) {
+	v, err := parser.ParseValue("42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	iv, ok := v.(*ast.IntValue)
+	if !ok {
+		t.Fatalf("got %T; want *ast.IntValue", v)
+	}
+	if iv.Value != "42" {
+		t.Errorf("Value = %q; want 42", iv.Value)
+	}
+}
+
+func TestParseValue_Float(t *testing.T) {
+	v, err := parser.ParseValue("3.14")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fv, ok := v.(*ast.FloatValue)
+	if !ok {
+		t.Fatalf("got %T; want *ast.FloatValue", v)
+	}
+	if fv.Value != "3.14" {
+		t.Errorf("Value = %q; want 3.14", fv.Value)
+	}
+}
+
+func TestParseValue_String(t *testing.T) {
+	v, err := parser.ParseValue(`"hello"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv, ok := v.(*ast.StringValue)
+	if !ok {
+		t.Fatalf("got %T; want *ast.StringValue", v)
+	}
+	if sv.Value != "hello" || sv.Block {
+		t.Errorf("got Value=%q Block=%v; want hello/false", sv.Value, sv.Block)
+	}
+}
+
+func TestParseValue_BlockString(t *testing.T) {
+	v, err := parser.ParseValue(`"""hi"""`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv, ok := v.(*ast.StringValue)
+	if !ok {
+		t.Fatalf("got %T", v)
+	}
+	if !sv.Block || sv.Value != "hi" {
+		t.Errorf("got Value=%q Block=%v; want hi/true", sv.Value, sv.Block)
+	}
+}
+
+func TestParseValue_Boolean(t *testing.T) {
+	for _, c := range []struct {
+		body string
+		want bool
+	}{{"true", true}, {"false", false}} {
+		v, err := parser.ParseValue(c.body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bv, ok := v.(*ast.BooleanValue)
+		if !ok {
+			t.Fatalf("body %q: got %T", c.body, v)
+		}
+		if bv.Value != c.want {
+			t.Errorf("body %q: got %v; want %v", c.body, bv.Value, c.want)
+		}
+	}
+}
+
+func TestParseValue_Null(t *testing.T) {
+	v, err := parser.ParseValue("null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := v.(*ast.NullValue); !ok {
+		t.Fatalf("got %T; want *ast.NullValue", v)
+	}
+}
+
+func TestParseValue_Enum(t *testing.T) {
+	v, err := parser.ParseValue("RED")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev, ok := v.(*ast.EnumValue)
+	if !ok {
+		t.Fatalf("got %T; want *ast.EnumValue", v)
+	}
+	if ev.Value != "RED" {
+		t.Errorf("Value = %q; want RED", ev.Value)
+	}
+}
+
+func TestParseValue_EnumKeywordsExcluded(t *testing.T) {
+	// true, false, null are NOT enum values.
+	for _, body := range []string{"true", "false", "null"} {
+		v, err := parser.ParseValue(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := v.(*ast.EnumValue); ok {
+			t.Errorf("body %q parsed as EnumValue; should be Boolean/Null", body)
+		}
+	}
+}
+
+func TestParseValue_List(t *testing.T) {
+	v, err := parser.ParseValue("[1, 2, 3]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lv, ok := v.(*ast.ListValue)
+	if !ok {
+		t.Fatalf("got %T; want *ast.ListValue", v)
+	}
+	if len(lv.Values) != 3 {
+		t.Fatalf("len = %d; want 3", len(lv.Values))
+	}
+	for i, want := range []string{"1", "2", "3"} {
+		iv, ok := lv.Values[i].(*ast.IntValue)
+		if !ok || iv.Value != want {
+			t.Errorf("element %d: got %T %v; want IntValue %q", i, lv.Values[i], lv.Values[i], want)
+		}
+	}
+}
+
+func TestParseValue_ListEmpty(t *testing.T) {
+	v, err := parser.ParseValue("[]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lv, ok := v.(*ast.ListValue)
+	if !ok {
+		t.Fatalf("got %T", v)
+	}
+	if len(lv.Values) != 0 {
+		t.Errorf("len = %d; want 0", len(lv.Values))
+	}
+}
+
+func TestParseValue_ListNested(t *testing.T) {
+	v, err := parser.ParseValue("[[1], [2, 3]]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lv := v.(*ast.ListValue)
+	if len(lv.Values) != 2 {
+		t.Fatalf("outer len = %d; want 2", len(lv.Values))
+	}
+	inner := lv.Values[1].(*ast.ListValue)
+	if len(inner.Values) != 2 {
+		t.Errorf("inner len = %d; want 2", len(inner.Values))
+	}
+}
+
+func TestParseValue_Object(t *testing.T) {
+	v, err := parser.ParseValue(`{a: 1, b: "hi", c: null}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ov, ok := v.(*ast.ObjectValue)
+	if !ok {
+		t.Fatalf("got %T; want *ast.ObjectValue", v)
+	}
+	if len(ov.Fields) != 3 {
+		t.Fatalf("len = %d; want 3", len(ov.Fields))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if ov.Fields[i].Name != want {
+			t.Errorf("field %d: name = %q; want %q", i, ov.Fields[i].Name, want)
+		}
+	}
+}
+
+func TestParseValue_ObjectEmpty(t *testing.T) {
+	v, err := parser.ParseValue("{}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ov := v.(*ast.ObjectValue)
+	if len(ov.Fields) != 0 {
+		t.Errorf("len = %d; want 0", len(ov.Fields))
+	}
+}
+
+func TestParseValue_Variable(t *testing.T) {
+	v, err := parser.ParseValue("$x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	vv, ok := v.(*ast.Variable)
+	if !ok {
+		t.Fatalf("got %T; want *ast.Variable", v)
+	}
+	if vv.Name != "x" {
+		t.Errorf("Name = %q; want x", vv.Name)
+	}
+}
+
+func TestParseConstValue_RejectsVariable(t *testing.T) {
+	if _, err := parser.ParseConstValue("$x"); err == nil {
+		t.Error("expected error for variable in const context")
+	}
+}
+
+func TestParseConstValue_RejectsNestedVariable(t *testing.T) {
+	cases := []string{"[$x]", "{a: $x}", "[1, $x, 3]"}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			if _, err := parser.ParseConstValue(body); err == nil {
+				t.Errorf("body %q: expected error", body)
+			}
+		})
+	}
+}
+
+func TestParseValue_NegativeNumber(t *testing.T) {
+	v, err := parser.ParseValue("-42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if iv, ok := v.(*ast.IntValue); !ok || iv.Value != "-42" {
+		t.Errorf("got %T %v; want IntValue -42", v, v)
+	}
+}
+
+func TestParseValue_LeftoverInputIsError(t *testing.T) {
+	if _, err := parser.ParseValue("1 2"); err == nil {
+		t.Error("expected error for trailing input")
+	}
+}
+
+func TestParseValue_EmptyInputIsError(t *testing.T) {
+	if _, err := parser.ParseValue(""); err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestParseValue_LocationCoversWholeValue(t *testing.T) {
+	v, err := parser.ParseValue("[1, 2, 3]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	loc := v.GetLoc()
+	if loc == nil {
+		t.Fatal("Loc is nil")
+	}
+	if loc.Start != 0 || loc.End != 9 {
+		t.Errorf("Loc = [%d, %d); want [0, 9)", loc.Start, loc.End)
+	}
+}
+
+func TestParseType_Named(t *testing.T) {
+	tt, err := parser.ParseType("User")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nt, ok := tt.(*ast.NamedType)
+	if !ok {
+		t.Fatalf("got %T; want *ast.NamedType", tt)
+	}
+	if nt.Name != "User" {
+		t.Errorf("Name = %q; want User", nt.Name)
+	}
+}
+
+func TestParseType_List(t *testing.T) {
+	tt, err := parser.ParseType("[String]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lt, ok := tt.(*ast.ListType)
+	if !ok {
+		t.Fatalf("got %T; want *ast.ListType", tt)
+	}
+	if nt, ok := lt.OfType.(*ast.NamedType); !ok || nt.Name != "String" {
+		t.Errorf("inner: got %T; want NamedType String", lt.OfType)
+	}
+}
+
+func TestParseType_NonNull(t *testing.T) {
+	tt, err := parser.ParseType("Int!")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nn, ok := tt.(*ast.NonNullType)
+	if !ok {
+		t.Fatalf("got %T; want *ast.NonNullType", tt)
+	}
+	if nt, ok := nn.OfType.(*ast.NamedType); !ok || nt.Name != "Int" {
+		t.Errorf("inner: got %T; want NamedType Int", nn.OfType)
+	}
+}
+
+func TestParseType_ListOfNonNull(t *testing.T) {
+	// [Int!] — list of non-null int
+	tt, err := parser.ParseType("[Int!]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lt := tt.(*ast.ListType)
+	nn := lt.OfType.(*ast.NonNullType)
+	if nt := nn.OfType.(*ast.NamedType); nt.Name != "Int" {
+		t.Errorf("inner: %v", nt)
+	}
+}
+
+func TestParseType_NonNullList(t *testing.T) {
+	// [Int]! — non-null list of nullable int
+	tt, err := parser.ParseType("[Int]!")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nn := tt.(*ast.NonNullType)
+	lt := nn.OfType.(*ast.ListType)
+	if nt := lt.OfType.(*ast.NamedType); nt.Name != "Int" {
+		t.Errorf("inner: %v", nt)
+	}
+}
+
+func TestParseType_DoubleNonNullRejected(t *testing.T) {
+	// Int!! is not a valid type per spec.
+	if _, err := parser.ParseType("Int!!"); err == nil {
+		t.Error("expected error for Int!!")
+	}
+}
+
+func TestParseType_UnclosedListRejected(t *testing.T) {
+	for _, body := range []string{"[", "[Int", "[Int]]"} {
+		t.Run(body, func(t *testing.T) {
+			if _, err := parser.ParseType(body); err == nil {
+				t.Errorf("body %q: expected error", body)
+			}
+		})
+	}
+}
+
+func TestParseType_LocationCoversWholeType(t *testing.T) {
+	tt, err := parser.ParseType("[Int!]!")
+	if err != nil {
+		t.Fatal(err)
+	}
+	loc := tt.GetLoc()
+	if loc == nil {
+		t.Fatal("nil Loc")
+	}
+	if loc.Start != 0 || loc.End != 7 {
+		t.Errorf("Loc = [%d, %d); want [0, 7)", loc.Start, loc.End)
+	}
+}
+
+func TestParseType_EmptyInputIsError(t *testing.T) {
+	if _, err := parser.ParseType(""); err == nil {
+		t.Error("expected error for empty input")
+	}
+}


### PR DESCRIPTION
## Summary

First end-to-end implementation of the GraphQL parser library, executed in 14 phases of the design plan. The branch is the entire project so far; merging this into the empty `main` is the v0 baseline.

### What's included

- **`ast/`** — `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; concrete pointer-receiver structs for every spec production; `Source` / `Position` / `Loc` (full-extent byte offsets, lazy line-start index); `BlockStringValue` helper; `Walk` / `Inspect`; `SyntaxError` with graphql-js-style snippet + caret rendering.
- **`lexer/`** — synchronous, single-token-lookahead, hand-written. Full October 2021 token set including `\u{...}` variable-length Unicode escapes and surrogate-pair recombination. Block-string dedent at lex time. Optional `PreserveComments`.
- **`parser/`** — recursive descent over both grammars (executable + SDL). Public API: `Parse`, `ParseSource`, `ParseValue`, `ParseConstValue`, `ParseType`. Variadic options: `WithRecovery()` (collects errors, inserts `BadDefinition` / `BadField` placeholders) and `WithComments()` (attaches `# ...` line comments as `Leading` trivia on definition-level nodes).

### Numbers

- **471 passing tests**, race-clean. ~4,300 lines of production code, ~3,200 lines of tests.
- 85-case ported subset of the graphql-js parser/lexer/schema-parser conformance corpus (table-driven, easily extended).
- 5s of fuzzing across 4 targets finds no panics over ~2.5M executions.
- Benchmarks (Apple M5): ~1.35 µs / 39 allocs per tiny query; ~80 MB/s on schema input.

### Design rationale

Captured locally in a 17-decision plan file. The headline trade-off vs. existing Go GraphQL parsers: full-extent `*ast.Loc` covering each node's whole range (not just the start), making formatters / LSPs / range-format possible. CLAUDE.md summarizes the non-obvious invariants for future contributors.

### Out of scope for v0

Validation, execution, schema introspection, a printer/formatter. Each is a natural follow-up library.

## Test plan

- [x] \`go test -race ./...\` — green on darwin/arm64
- [x] \`gofmt -l .\` empty
- [x] \`go vet ./...\` clean
- [x] 5s fuzz on every target — no panics
- [x] Benchmarks run cleanly
- [x] CI green on linux+darwin × Go 1.25 / 1.26 (pending Actions run)
- [ ] Long fuzz schedule fires without findings (24h after merge)