### PR TITLE
Add low-level SDL AST helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ LSP can depend on AST types without dragging in the parser.
 
 ### Package responsibilities
 
-- `ast/` - `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; concrete pointer-receiver structs for every spec production; `Source`, `Position`, `Loc` with a lazy line-start index; `BlockStringValue` helper; `Walk`/`Inspect`; `SyntaxError` with the graphql-js-style snippet renderer.
+- `ast/` - `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; concrete pointer-receiver structs for every spec production; `Source`, `Position`, `Loc` with a lazy line-start index; `BlockStringValue`, `TypeString`, `NamedTypeName`, and `DirectiveStringArg` helpers; `Walk`/`Inspect`; `SyntaxError` with the graphql-js-style snippet renderer.
 - `lexer/` - synchronous, single-token-lookahead, hand-written tokenizer. `Token` carries byte offsets plus a `Value` that is a sub-slice of source for `NAME`/`INT`/`FLOAT`. `STRING` tokens own their decoded value. `Lexer.PreserveComments` is the internal switch the parser flips for `WithComments`.
 - `parser/` - recursive descent. Public API is `Parse`, `ParseSource`, `ParseSchema`, `ParseSchemaSource`, `ParseValue`, `ParseConstValue`, `ParseType`, plus `WithRecovery()` and `WithComments()`. Everything else is unexported.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AST. Supports both grammars from the
 documents and the type-system / SDL — in three small packages:
 
 ```
-github.com/brian-bell/graphql-parser/ast    // node types, Source, Position, Loc, Walk
+github.com/brian-bell/graphql-parser/ast    // node types, Source, Position, Loc, Walk, AST helpers
 github.com/brian-bell/graphql-parser/lexer  // tokenizer
 github.com/brian-bell/graphql-parser/parser // Parse, ParseSource, ParseSchema, ParseSchemaSource, ParseValue, ParseConstValue, ParseType
 ```
@@ -69,6 +69,23 @@ t, err := parser.ParseType(`[String!]!`)
 
 `ParseConstValue` is the const-context variant; it rejects `$variables` at
 any nesting depth. Use it for default-value parsing.
+
+### Inspect common AST values
+
+The `ast` package includes small helpers for common SDL tooling tasks:
+
+```go
+import "github.com/brian-bell/graphql-parser/ast"
+
+fmt.Println(ast.TypeString(t))    // [String!]!
+fmt.Println(ast.NamedTypeName(t)) // String
+
+reason, ok := ast.DirectiveStringArg(enumValue.Directives, "deprecated", "reason")
+```
+
+`DirectiveStringArg` returns the decoded string value and `true` only when the
+argument is present and is a string literal. An explicit empty string returns
+`("", true)`; missing, nil, or non-string values return `("", false)`.
 
 ### Position-rich errors
 

--- a/ast/directive_helpers_test.go
+++ b/ast/directive_helpers_test.go
@@ -102,19 +102,6 @@ func TestDirectiveStringArg_ReturnsFalseForMissingNilOrNonString(t *testing.T) {
 			arg: "reason",
 		},
 		{
-			name: "first matching directive without argument wins",
-			dirs: ast.DirectiveList{
-				&ast.Directive{Name: "deprecated"},
-				&ast.Directive{
-					Name: "deprecated",
-					Arguments: ast.ArgumentList{
-						&ast.Argument{Name: "reason", Value: &ast.StringValue{Value: "later"}},
-					},
-				},
-			},
-			arg: "reason",
-		},
-		{
 			name: "first matching argument non-string wins",
 			dirs: ast.DirectiveList{
 				&ast.Directive{
@@ -135,5 +122,23 @@ func TestDirectiveStringArg_ReturnsFalseForMissingNilOrNonString(t *testing.T) {
 				t.Fatalf("DirectiveStringArg() = %q, %v; want empty string, false", got, ok)
 			}
 		})
+	}
+}
+
+func TestDirectiveStringArg_ScansRepeatableDirectives(t *testing.T) {
+	dirs := ast.DirectiveList{
+		&ast.Directive{Name: "tag"},
+		&ast.Directive{Name: "other"},
+		&ast.Directive{
+			Name: "tag",
+			Arguments: ast.ArgumentList{
+				&ast.Argument{Name: "name", Value: &ast.StringValue{Value: "later"}},
+			},
+		},
+	}
+
+	got, ok := ast.DirectiveStringArg(dirs, "tag", "name")
+	if got != "later" || !ok {
+		t.Fatalf("DirectiveStringArg() = %q, %v; want %q, true", got, ok, "later")
 	}
 }

--- a/ast/directive_helpers_test.go
+++ b/ast/directive_helpers_test.go
@@ -1,0 +1,92 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
+)
+
+func TestDirectiveStringArg_ReturnsStringValue(t *testing.T) {
+	doc, err := parser.ParseSchema(`
+		enum Color {
+			BLUE @deprecated(reason: "use INDIGO")
+			EMPTY @deprecated(reason: "")
+		}
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enumDef := doc.Definitions[0].(*ast.EnumTypeDefinition)
+
+	blue := enumDef.Values.ForName("BLUE")
+	got, ok := ast.DirectiveStringArg(blue.Directives, "deprecated", "reason")
+	if got != "use INDIGO" || !ok {
+		t.Fatalf("DirectiveStringArg(BLUE) = %q, %v; want %q, true", got, ok, "use INDIGO")
+	}
+
+	empty := enumDef.Values.ForName("EMPTY")
+	got, ok = ast.DirectiveStringArg(empty.Directives, "deprecated", "reason")
+	if got != "" || !ok {
+		t.Fatalf("DirectiveStringArg(EMPTY) = %q, %v; want empty string, true", got, ok)
+	}
+}
+
+func TestDirectiveStringArg_ReturnsFalseForMissingNilOrNonString(t *testing.T) {
+	doc, err := parser.ParseSchema(`
+		enum Color {
+			RED @deprecated
+			GREEN
+			BLUE @deprecated(reason: 123)
+		}
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enumDef := doc.Definitions[0].(*ast.EnumTypeDefinition)
+
+	cases := []struct {
+		name string
+		dirs ast.DirectiveList
+		arg  string
+	}{
+		{name: "missing argument", dirs: enumDef.Values.ForName("RED").Directives, arg: "reason"},
+		{name: "missing directive", dirs: enumDef.Values.ForName("GREEN").Directives, arg: "reason"},
+		{name: "non-string argument", dirs: enumDef.Values.ForName("BLUE").Directives, arg: "reason"},
+		{name: "wrong argument name", dirs: enumDef.Values.ForName("BLUE").Directives, arg: "missing"},
+		{
+			name: "nil entries",
+			dirs: ast.DirectiveList{
+				nil,
+				&ast.Directive{
+					Name: "deprecated",
+					Arguments: ast.ArgumentList{
+						nil,
+						&ast.Argument{Name: "reason", Value: &ast.IntValue{Value: "123"}},
+					},
+				},
+			},
+			arg: "reason",
+		},
+		{
+			name: "nil argument value",
+			dirs: ast.DirectiveList{
+				&ast.Directive{
+					Name: "deprecated",
+					Arguments: ast.ArgumentList{
+						&ast.Argument{Name: "reason"},
+					},
+				},
+			},
+			arg: "reason",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ast.DirectiveStringArg(tc.dirs, "deprecated", tc.arg)
+			if got != "" || ok {
+				t.Fatalf("DirectiveStringArg() = %q, %v; want empty string, false", got, ok)
+			}
+		})
+	}
+}

--- a/ast/directive_helpers_test.go
+++ b/ast/directive_helpers_test.go
@@ -12,6 +12,7 @@ func TestDirectiveStringArg_ReturnsStringValue(t *testing.T) {
 		enum Color {
 			BLUE @deprecated(reason: "use INDIGO")
 			EMPTY @deprecated(reason: "")
+			ESCAPED @deprecated(reason: "use \u0049NDIGO")
 		}
 	`)
 	if err != nil {
@@ -30,9 +31,17 @@ func TestDirectiveStringArg_ReturnsStringValue(t *testing.T) {
 	if got != "" || !ok {
 		t.Fatalf("DirectiveStringArg(EMPTY) = %q, %v; want empty string, true", got, ok)
 	}
+
+	escaped := enumDef.Values.ForName("ESCAPED")
+	got, ok = ast.DirectiveStringArg(escaped.Directives, "deprecated", "reason")
+	if got != "use INDIGO" || !ok {
+		t.Fatalf("DirectiveStringArg(ESCAPED) = %q, %v; want %q, true", got, ok, "use INDIGO")
+	}
 }
 
 func TestDirectiveStringArg_ReturnsFalseForMissingNilOrNonString(t *testing.T) {
+	var nilString *ast.StringValue
+
 	doc, err := parser.ParseSchema(`
 		enum Color {
 			RED @deprecated
@@ -75,6 +84,44 @@ func TestDirectiveStringArg_ReturnsFalseForMissingNilOrNonString(t *testing.T) {
 					Name: "deprecated",
 					Arguments: ast.ArgumentList{
 						&ast.Argument{Name: "reason"},
+					},
+				},
+			},
+			arg: "reason",
+		},
+		{
+			name: "typed nil string value",
+			dirs: ast.DirectiveList{
+				&ast.Directive{
+					Name: "deprecated",
+					Arguments: ast.ArgumentList{
+						&ast.Argument{Name: "reason", Value: nilString},
+					},
+				},
+			},
+			arg: "reason",
+		},
+		{
+			name: "first matching directive without argument wins",
+			dirs: ast.DirectiveList{
+				&ast.Directive{Name: "deprecated"},
+				&ast.Directive{
+					Name: "deprecated",
+					Arguments: ast.ArgumentList{
+						&ast.Argument{Name: "reason", Value: &ast.StringValue{Value: "later"}},
+					},
+				},
+			},
+			arg: "reason",
+		},
+		{
+			name: "first matching argument non-string wins",
+			dirs: ast.DirectiveList{
+				&ast.Directive{
+					Name: "deprecated",
+					Arguments: ast.ArgumentList{
+						&ast.Argument{Name: "reason", Value: &ast.IntValue{Value: "123"}},
+						&ast.Argument{Name: "reason", Value: &ast.StringValue{Value: "later"}},
 					},
 				},
 			},

--- a/ast/document.go
+++ b/ast/document.go
@@ -44,9 +44,9 @@ func (dl DirectiveList) ForName(name string) *Directive {
 }
 
 // DirectiveStringArg returns the decoded string value for the first matching
-// directive argument. It returns ("", false) when the directive or argument is
-// absent, nil, or not a StringValue. An explicit empty string returns ("",
-// true).
+// directive argument, scanning repeated directives with the same name. It
+// returns ("", false) when the directive or argument is absent, nil, or not a
+// StringValue. An explicit empty string returns ("", true).
 func DirectiveStringArg(dirs DirectiveList, directiveName, argumentName string) (string, bool) {
 	for _, dir := range dirs {
 		if dir == nil || dir.Name != directiveName {
@@ -62,7 +62,6 @@ func DirectiveStringArg(dirs DirectiveList, directiveName, argumentName string) 
 			}
 			return value.Value, true
 		}
-		return "", false
 	}
 	return "", false
 }

--- a/ast/document.go
+++ b/ast/document.go
@@ -43,6 +43,30 @@ func (dl DirectiveList) ForName(name string) *Directive {
 	return nil
 }
 
+// DirectiveStringArg returns the decoded string value for the first matching
+// directive argument. It returns ("", false) when the directive or argument is
+// absent, nil, or not a StringValue. An explicit empty string returns ("",
+// true).
+func DirectiveStringArg(dirs DirectiveList, directiveName, argumentName string) (string, bool) {
+	for _, dir := range dirs {
+		if dir == nil || dir.Name != directiveName {
+			continue
+		}
+		for _, arg := range dir.Arguments {
+			if arg == nil || arg.Name != argumentName {
+				continue
+			}
+			value, ok := arg.Value.(*StringValue)
+			if !ok || value == nil {
+				return "", false
+			}
+			return value.Value, true
+		}
+		return "", false
+	}
+	return "", false
+}
+
 // VariableDefinitionList is a slice of *VariableDefinition.
 type VariableDefinitionList []*VariableDefinition
 

--- a/ast/type.go
+++ b/ast/type.go
@@ -28,3 +28,65 @@ type NonNullType struct {
 
 func (t *NonNullType) GetLoc() *Loc { return t.Loc }
 func (*NonNullType) isType()        {}
+
+// TypeString returns the canonical type-reference spelling for t, or "" when
+// t is nil, a BadType, or a malformed type reference.
+func TypeString(t Type) string {
+	switch t := t.(type) {
+	case *NamedType:
+		if t == nil {
+			return ""
+		}
+		return t.Name
+	case *ListType:
+		if t == nil {
+			return ""
+		}
+		inner := TypeString(t.OfType)
+		if inner == "" {
+			return ""
+		}
+		return "[" + inner + "]"
+	case *NonNullType:
+		if t == nil {
+			return ""
+		}
+		if _, ok := t.OfType.(*NonNullType); ok {
+			return ""
+		}
+		inner := TypeString(t.OfType)
+		if inner == "" {
+			return ""
+		}
+		return inner + "!"
+	default:
+		return ""
+	}
+}
+
+// NamedTypeName returns the innermost named type name for t, or "" when t is
+// nil, a BadType, or a malformed type reference.
+func NamedTypeName(t Type) string {
+	switch t := t.(type) {
+	case *NamedType:
+		if t == nil {
+			return ""
+		}
+		return t.Name
+	case *ListType:
+		if t == nil {
+			return ""
+		}
+		return NamedTypeName(t.OfType)
+	case *NonNullType:
+		if t == nil {
+			return ""
+		}
+		if _, ok := t.OfType.(*NonNullType); ok {
+			return ""
+		}
+		return NamedTypeName(t.OfType)
+	default:
+		return ""
+	}
+}

--- a/ast/type_helpers_test.go
+++ b/ast/type_helpers_test.go
@@ -1,0 +1,76 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
+)
+
+func TestTypeString_RendersWrappedTypes(t *testing.T) {
+	cases := []string{
+		"Book",
+		"Book!",
+		"[Book]",
+		"[Book!]!",
+		"[[Book!]!]",
+	}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			typ, err := parser.ParseType(input)
+			if err != nil {
+				t.Fatalf("ParseType(%q): %v", input, err)
+			}
+			if got := ast.TypeString(typ); got != input {
+				t.Fatalf("TypeString(%q) = %q, want %q", input, got, input)
+			}
+		})
+	}
+}
+
+func TestNamedTypeName_UnwrapsWrappedTypes(t *testing.T) {
+	cases := []string{
+		"Book",
+		"Book!",
+		"[Book]",
+		"[Book!]!",
+		"[[Book!]!]",
+	}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			typ, err := parser.ParseType(input)
+			if err != nil {
+				t.Fatalf("ParseType(%q): %v", input, err)
+			}
+			if got := ast.NamedTypeName(typ); got != "Book" {
+				t.Fatalf("NamedTypeName(%q) = %q, want %q", input, got, "Book")
+			}
+		})
+	}
+}
+
+func TestTypeHelpers_ReturnEmptyForInvalidTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  ast.Type
+	}{
+		{name: "nil"},
+		{name: "bad type", typ: &ast.BadType{}},
+		{name: "list with nil inner", typ: &ast.ListType{}},
+		{name: "non-null with nil inner", typ: &ast.NonNullType{}},
+		{
+			name: "double non-null",
+			typ:  &ast.NonNullType{OfType: &ast.NonNullType{OfType: &ast.NamedType{Name: "Book"}}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ast.TypeString(tc.typ); got != "" {
+				t.Fatalf("TypeString() = %q, want empty string", got)
+			}
+			if got := ast.NamedTypeName(tc.typ); got != "" {
+				t.Fatalf("NamedTypeName() = %q, want empty string", got)
+			}
+		})
+	}
+}

--- a/ast/type_helpers_test.go
+++ b/ast/type_helpers_test.go
@@ -50,11 +50,18 @@ func TestNamedTypeName_UnwrapsWrappedTypes(t *testing.T) {
 }
 
 func TestTypeHelpers_ReturnEmptyForInvalidTypes(t *testing.T) {
+	var nilNamed *ast.NamedType
+	var nilList *ast.ListType
+	var nilNonNull *ast.NonNullType
+
 	cases := []struct {
 		name string
 		typ  ast.Type
 	}{
 		{name: "nil"},
+		{name: "typed nil named", typ: nilNamed},
+		{name: "typed nil list", typ: nilList},
+		{name: "typed nil non-null", typ: nilNonNull},
 		{name: "bad type", typ: &ast.BadType{}},
 		{name: "list with nil inner", typ: &ast.ListType{}},
 		{name: "non-null with nil inner", typ: &ast.NonNullType{}},


### PR DESCRIPTION
## Summary

- Add `ast.TypeString` for canonical rendering of GraphQL type references such as `[Book!]!`.
- Add `ast.NamedTypeName` to unwrap list and non-null wrappers to the innermost named type.
- Add `ast.DirectiveStringArg` for reading decoded string arguments from named directives, including predictable false results for missing and non-string values.
- Document the helper APIs in the README and cover edge cases with AST package tests.

Closes #9

## Verification

- `gofmt -l .`
- `go test ./...`
- `go vet ./...`
- `git diff --check origin/main...HEAD`
