### PR TITLE
Add schema index API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,12 @@ Module path: `github.com/brian-bell/graphql-parser`. Go 1.26 floor.
 
 ## Architecture
 
-Three packages with a strict dependency DAG:
+Four packages with a strict dependency DAG:
 
 ```text
 lexer -> ast
 parser -> ast, lexer
+schemaindex -> ast
 ```
 
 `ast/` is intentionally importable on its own. A future printer, formatter, or
@@ -34,6 +35,7 @@ LSP can depend on AST types without dragging in the parser.
 - `ast/` - `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; concrete pointer-receiver structs for every spec production; `Source`, `Position`, `Loc` with a lazy line-start index; `BlockStringValue`, `TypeString`, `NamedTypeName`, and `DirectiveStringArg` helpers; `Walk`/`Inspect`; `SyntaxError` with the graphql-js-style snippet renderer.
 - `lexer/` - synchronous, single-token-lookahead, hand-written tokenizer. `Token` carries byte offsets plus a `Value` that is a sub-slice of source for `NAME`/`INT`/`FLOAT`. `STRING` tokens own their decoded value. `Lexer.PreserveComments` is the internal switch the parser flips for `WithComments`.
 - `parser/` - recursive descent. Public API is `Parse`, `ParseSource`, `ParseSchema`, `ParseSchemaSource`, `ParseValue`, `ParseConstValue`, `ParseType`, plus `WithRecovery()` and `WithComments()`. Everything else is unexported.
+- `schemaindex/` - small public SDL index over a parsed `*ast.Document`. `New` records the six named type definitions and six matching extension forms by name, keeps base definitions and extensions separate in source order, ignores non-type definitions, and does not validate or fold schema semantics.
 
 ### Key invariants
 
@@ -99,6 +101,7 @@ the hot path. Tokens carry byte offsets, not copied strings, for
 - `parser/corpus_test.go` - graphql-js parser/lexer/schema-parser conformance, table-driven
 - `parser/schema_api_test.go` - schema-only `ParseSchema*` public API behavior
 - `parser/recover_test.go` / `parser/comments_test.go` - option-specific behavior
+- `schemaindex/index_test.go` / `schemaindex/example_test.go` - public schema index behavior and usage
 - `parser/fuzz_test.go` - `FuzzParse`, `FuzzParseWithRecovery`, `FuzzParseValue`, `FuzzParseType` with shared seed corpus
 - `parser/benchmark_test.go` - tiny query, mid-size schema, large schema benchmarks
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 A small, dependency-free Go library that parses GraphQL source text into an
 AST. Supports both grammars from the
 [October 2021 GraphQL spec](https://spec.graphql.org/October2021/) — executable
-documents and the type-system / SDL — in three small packages:
+documents and the type-system / SDL — in four small packages:
 
 ```
 github.com/brian-bell/graphql-parser/ast    // node types, Source, Position, Loc, Walk, AST helpers
 github.com/brian-bell/graphql-parser/lexer  // tokenizer
 github.com/brian-bell/graphql-parser/parser // Parse, ParseSource, ParseSchema, ParseSchemaSource, ParseValue, ParseConstValue, ParseType
+github.com/brian-bell/graphql-parser/schemaindex // SDL type-definition lookup by name
 ```
 
 Validation, execution, and printing are out of scope.
@@ -59,6 +60,37 @@ schemaDoc, err := parser.ParseSchema(`
     }
 `)
 ```
+
+### Index SDL definitions
+
+Use `schemaindex` to look up parsed SDL type definitions and extensions by
+name while preserving source order.
+
+```go
+import (
+    "fmt"
+
+    "github.com/brian-bell/graphql-parser/ast"
+    "github.com/brian-bell/graphql-parser/parser"
+    "github.com/brian-bell/graphql-parser/schemaindex"
+)
+
+schemaDoc, err := parser.ParseSchema(`
+    type Query { user: User }
+    extend type Query { viewer: User }
+`)
+if err != nil { panic(err) }
+
+idx := schemaindex.New(schemaDoc)
+query := idx.LookupType("Query")
+base := query.BaseDefinitions()[0].(*ast.ObjectTypeDefinition)
+ext := query.Extensions()[0].(*ast.ObjectTypeExtension)
+
+fmt.Println(base.Name, ext.Fields[0].Name)
+```
+
+The index does not validate schema semantics, enforce duplicate-name rules, or
+fold extensions into base definitions.
 
 ### Parse a single value or type literal
 

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -13,11 +13,11 @@ load-bearing feature of the project.
 
 ## Rules
 
-1. **No `regexp`** in `lexer/` or `parser/`.
-   The grammar is small enough to hand-write. Regexp's setup cost on a
-   per-parse basis swamps the parsing itself for small inputs.
+1. **No `regexp`** in `lexer/`, `parser/`, or `schemaindex/`.
+   The grammar and SDL index are small enough to hand-write. Regexp's setup
+   cost on a per-parse basis swamps the parsing itself for small inputs.
 
-2. **No `reflect`** in `lexer/`, `parser/`, or `ast/walk.go`.
+2. **No `reflect`** in `lexer/`, `parser/`, `schemaindex/`, or `ast/walk.go`.
    The AST has ~40 concrete node types. Type switches are cheaper, easier
    to read, and produce useful compile-time errors when a node kind is
    missed.
@@ -44,9 +44,9 @@ load-bearing feature of the project.
 
 - `gofmt -l .` is empty.
 - `go vet ./...` is clean.
-- `grep -rn 'regexp\|reflect\|fmt.Sprintf' lexer/ parser/ ast/` returns
-  only allowed sites: `ast/error.go`, `ast/loc.go` (column formatting in
-  `Position.String`), and the comment-permitted error-message path in
+- `grep -rn 'regexp\|reflect\|fmt.Sprintf' lexer/ parser/ ast/ schemaindex/`
+  returns only allowed sites: `ast/error.go`, `ast/loc.go` (column formatting
+  in `Position.String`), and the comment-permitted error-message path in
   `parser/parser.go`'s `describeToken`.
 - Benchmarks in `parser/benchmark_test.go` run cleanly on every PR with
   `go test -bench=. -benchmem ./parser/`.

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -45,8 +45,8 @@ load-bearing feature of the project.
 - `gofmt -l .` is empty.
 - `go vet ./...` is clean.
 - `grep -rn 'regexp\|reflect\|fmt.Sprintf' lexer/ parser/ ast/ schemaindex/`
-  returns only allowed sites: `ast/error.go`, `ast/loc.go` (column formatting
-  in `Position.String`), and the comment-permitted error-message path in
+  returns only allowed sites: test files, `ast/error.go`, `ast/loc.go` (column
+  formatting in `Position.String`), lexer/parser error-message paths, and
   `parser/parser.go`'s `describeToken`.
 - Benchmarks in `parser/benchmark_test.go` run cleanly on every PR with
   `go test -bench=. -benchmem ./parser/`.

--- a/schemaindex/example_test.go
+++ b/schemaindex/example_test.go
@@ -1,0 +1,37 @@
+package schemaindex_test
+
+import (
+	"fmt"
+
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/schemaindex"
+)
+
+func ExampleIndex_LookupType() {
+	doc, err := parser.ParseSchema(`
+		type Book { title: String }
+		extend type Book { isbn: ID }
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	idx := schemaindex.New(doc)
+	book := idx.LookupType("Book")
+	base := book.BaseDefinitions()[0].(*ast.ObjectTypeDefinition)
+	ext := book.Extensions()[0].(*ast.ObjectTypeExtension)
+
+	fmt.Println(book.Name())
+	fmt.Println(len(book.BaseDefinitions()))
+	fmt.Println(len(book.Extensions()))
+	fmt.Printf("%T %s\n", base, base.Name)
+	fmt.Printf("%T %s\n", ext, ext.Fields[0].Name)
+
+	// Output:
+	// Book
+	// 1
+	// 1
+	// *ast.ObjectTypeDefinition Book
+	// *ast.ObjectTypeExtension isbn
+}

--- a/schemaindex/index.go
+++ b/schemaindex/index.go
@@ -1,0 +1,115 @@
+// Package schemaindex indexes parsed GraphQL SDL type definitions.
+//
+// The index records top-level named type definitions and matching extensions.
+// It does not validate schema semantics, merge duplicate definitions, or fold
+// extensions into their base definitions.
+package schemaindex
+
+import "github.com/brian-bell/graphql-parser/ast"
+
+// Index provides name-based lookup for parsed SDL type definitions.
+type Index struct {
+	types map[string]*TypeEntry
+}
+
+// New builds an index from doc. A nil document returns an empty index.
+func New(doc *ast.Document) *Index {
+	idx := &Index{types: make(map[string]*TypeEntry)}
+	if doc == nil {
+		return idx
+	}
+	for _, def := range doc.Definitions {
+		if name, ok := baseTypeName(def); ok {
+			entry := idx.entryFor(name)
+			entry.baseDefinitions = append(entry.baseDefinitions, def)
+			continue
+		}
+
+		if name, ok := extensionTypeName(def); ok {
+			entry := idx.entryFor(name)
+			entry.extensions = append(entry.extensions, def)
+		}
+	}
+	return idx
+}
+
+func (idx *Index) entryFor(name string) *TypeEntry {
+	entry := idx.types[name]
+	if entry == nil {
+		entry = &TypeEntry{name: name}
+		idx.types[name] = entry
+	}
+	return entry
+}
+
+func baseTypeName(def ast.Definition) (string, bool) {
+	switch d := def.(type) {
+	case *ast.ScalarTypeDefinition:
+		return d.Name, true
+	case *ast.ObjectTypeDefinition:
+		return d.Name, true
+	case *ast.InterfaceTypeDefinition:
+		return d.Name, true
+	case *ast.UnionTypeDefinition:
+		return d.Name, true
+	case *ast.EnumTypeDefinition:
+		return d.Name, true
+	case *ast.InputObjectTypeDefinition:
+		return d.Name, true
+	default:
+		return "", false
+	}
+}
+
+func extensionTypeName(def ast.Definition) (string, bool) {
+	switch d := def.(type) {
+	case *ast.ScalarTypeExtension:
+		return d.Name, true
+	case *ast.ObjectTypeExtension:
+		return d.Name, true
+	case *ast.InterfaceTypeExtension:
+		return d.Name, true
+	case *ast.UnionTypeExtension:
+		return d.Name, true
+	case *ast.EnumTypeExtension:
+		return d.Name, true
+	case *ast.InputObjectTypeExtension:
+		return d.Name, true
+	default:
+		return "", false
+	}
+}
+
+// LookupType returns the indexed type entry for name, or nil when absent.
+func (idx *Index) LookupType(name string) *TypeEntry {
+	return idx.types[name]
+}
+
+// TypeEntry contains the parsed base definitions and extensions for one type name.
+type TypeEntry struct {
+	name            string
+	baseDefinitions []ast.Definition
+	extensions      []ast.Definition
+}
+
+// Name returns the type name for this entry.
+func (e *TypeEntry) Name() string {
+	return e.name
+}
+
+// BaseDefinitions returns a shallow copy of the parsed base type definitions
+// for this entry. The AST nodes inside the returned slice are the original
+// parsed nodes.
+func (e *TypeEntry) BaseDefinitions() []ast.Definition {
+	return copyDefinitions(e.baseDefinitions)
+}
+
+// Extensions returns a shallow copy of the parsed type extensions for this
+// entry. The AST nodes inside the returned slice are the original parsed nodes.
+func (e *TypeEntry) Extensions() []ast.Definition {
+	return copyDefinitions(e.extensions)
+}
+
+func copyDefinitions(defs []ast.Definition) []ast.Definition {
+	return append([]ast.Definition(nil), defs...)
+}

--- a/schemaindex/index_test.go
+++ b/schemaindex/index_test.go
@@ -1,0 +1,337 @@
+package schemaindex_test
+
+import (
+	"testing"
+
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
+	"github.com/brian-bell/graphql-parser/schemaindex"
+)
+
+func TestNewIndexesNamedTypeDefinitionsByName(t *testing.T) {
+	doc := mustParseSchema(t, `
+		scalar URL
+		type Query { search: Search }
+		interface Node { id: ID! }
+		type User implements Node { id: ID! }
+		union Search = User
+		enum Color { RED GREEN }
+		input UserInput { id: ID }
+	`)
+
+	idx := schemaindex.New(doc)
+	cases := []struct {
+		name      string
+		assertDef func(t *testing.T, def ast.Definition)
+	}{
+		{
+			name: "URL",
+			assertDef: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.ScalarTypeDefinition); !ok {
+					t.Fatalf("definition = %T; want *ast.ScalarTypeDefinition", def)
+				}
+			},
+		},
+		{
+			name: "Query",
+			assertDef: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.ObjectTypeDefinition); !ok {
+					t.Fatalf("definition = %T; want *ast.ObjectTypeDefinition", def)
+				}
+			},
+		},
+		{
+			name: "Node",
+			assertDef: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.InterfaceTypeDefinition); !ok {
+					t.Fatalf("definition = %T; want *ast.InterfaceTypeDefinition", def)
+				}
+			},
+		},
+		{
+			name: "Search",
+			assertDef: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.UnionTypeDefinition); !ok {
+					t.Fatalf("definition = %T; want *ast.UnionTypeDefinition", def)
+				}
+			},
+		},
+		{
+			name: "Color",
+			assertDef: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.EnumTypeDefinition); !ok {
+					t.Fatalf("definition = %T; want *ast.EnumTypeDefinition", def)
+				}
+			},
+		},
+		{
+			name: "UserInput",
+			assertDef: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.InputObjectTypeDefinition); !ok {
+					t.Fatalf("definition = %T; want *ast.InputObjectTypeDefinition", def)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := idx.LookupType(tc.name)
+			if entry == nil {
+				t.Fatalf("LookupType(%q) = nil", tc.name)
+			}
+			if entry.Name() != tc.name {
+				t.Fatalf("entry.Name() = %q; want %q", entry.Name(), tc.name)
+			}
+			defs := entry.BaseDefinitions()
+			if len(defs) != 1 {
+				t.Fatalf("BaseDefinitions() length = %d; want 1", len(defs))
+			}
+			tc.assertDef(t, defs[0])
+			if got := len(entry.Extensions()); got != 0 {
+				t.Fatalf("Extensions() length = %d; want 0", got)
+			}
+		})
+	}
+
+	if got := idx.LookupType("Missing"); got != nil {
+		t.Fatalf("LookupType(%q) = %#v; want nil", "Missing", got)
+	}
+}
+
+func TestNewRecordsExtensionsSeparatelyInSourceOrder(t *testing.T) {
+	doc := mustParseSchema(t, `
+		extend scalar URL @specifiedBy(url: "https://example.com")
+		extend type Query { second: String }
+		type Query { first: String }
+		extend interface Node { name: String }
+		extend union Search = User
+		extend enum Status { ARCHIVED }
+		extend input UserInput { slug: String }
+		extend type Query { third: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	query := idx.LookupType("Query")
+	if query == nil {
+		t.Fatal(`LookupType("Query") = nil`)
+	}
+	if got := len(query.BaseDefinitions()); got != 1 {
+		t.Fatalf("Query BaseDefinitions() length = %d; want 1", got)
+	}
+	extensions := query.Extensions()
+	if got := len(extensions); got != 2 {
+		t.Fatalf("Query Extensions() length = %d; want 2", got)
+	}
+	firstExt := extensions[0].(*ast.ObjectTypeExtension)
+	secondExt := extensions[1].(*ast.ObjectTypeExtension)
+	if firstExt.Fields[0].Name != "second" {
+		t.Fatalf("first Query extension field = %q; want second", firstExt.Fields[0].Name)
+	}
+	if secondExt.Fields[0].Name != "third" {
+		t.Fatalf("second Query extension field = %q; want third", secondExt.Fields[0].Name)
+	}
+
+	cases := []struct {
+		name      string
+		assertExt func(t *testing.T, def ast.Definition)
+	}{
+		{
+			name: "URL",
+			assertExt: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.ScalarTypeExtension); !ok {
+					t.Fatalf("extension = %T; want *ast.ScalarTypeExtension", def)
+				}
+			},
+		},
+		{
+			name: "Node",
+			assertExt: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.InterfaceTypeExtension); !ok {
+					t.Fatalf("extension = %T; want *ast.InterfaceTypeExtension", def)
+				}
+			},
+		},
+		{
+			name: "Search",
+			assertExt: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.UnionTypeExtension); !ok {
+					t.Fatalf("extension = %T; want *ast.UnionTypeExtension", def)
+				}
+			},
+		},
+		{
+			name: "Status",
+			assertExt: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.EnumTypeExtension); !ok {
+					t.Fatalf("extension = %T; want *ast.EnumTypeExtension", def)
+				}
+			},
+		},
+		{
+			name: "UserInput",
+			assertExt: func(t *testing.T, def ast.Definition) {
+				t.Helper()
+				if _, ok := def.(*ast.InputObjectTypeExtension); !ok {
+					t.Fatalf("extension = %T; want *ast.InputObjectTypeExtension", def)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := idx.LookupType(tc.name)
+			if entry == nil {
+				t.Fatalf("LookupType(%q) = nil", tc.name)
+			}
+			if got := len(entry.BaseDefinitions()); got != 0 {
+				t.Fatalf("BaseDefinitions() length = %d; want 0", got)
+			}
+			extensions := entry.Extensions()
+			if got := len(extensions); got != 1 {
+				t.Fatalf("Extensions() length = %d; want 1", got)
+			}
+			tc.assertExt(t, extensions[0])
+		})
+	}
+}
+
+func TestNewPreservesDuplicateBaseDefinitionsInSourceOrder(t *testing.T) {
+	doc := mustParseSchema(t, `
+		type Query { first: String }
+		type Query { second: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	entry := idx.LookupType("Query")
+	if entry == nil {
+		t.Fatal(`LookupType("Query") = nil`)
+	}
+	defs := entry.BaseDefinitions()
+	if got := len(defs); got != 2 {
+		t.Fatalf("BaseDefinitions() length = %d; want 2", got)
+	}
+	first := defs[0].(*ast.ObjectTypeDefinition)
+	second := defs[1].(*ast.ObjectTypeDefinition)
+	if first.Fields[0].Name != "first" {
+		t.Fatalf("first Query base definition field = %q; want first", first.Fields[0].Name)
+	}
+	if second.Fields[0].Name != "second" {
+		t.Fatalf("second Query base definition field = %q; want second", second.Fields[0].Name)
+	}
+}
+
+func TestNewDoesNotValidateSchemaSemantics(t *testing.T) {
+	doc := mustParseSchema(t, `
+		type Query { missing: Missing @unknown }
+		interface Query { id: ID! }
+		extend type Product @key(fields: "id") { id: ID! related: Missing }
+	`)
+
+	idx := schemaindex.New(doc)
+	query := idx.LookupType("Query")
+	if query == nil {
+		t.Fatal(`LookupType("Query") = nil`)
+	}
+	defs := query.BaseDefinitions()
+	if got := len(defs); got != 2 {
+		t.Fatalf("Query BaseDefinitions() length = %d; want 2", got)
+	}
+	if _, ok := defs[0].(*ast.ObjectTypeDefinition); !ok {
+		t.Fatalf("Query definition[0] = %T; want *ast.ObjectTypeDefinition", defs[0])
+	}
+	if _, ok := defs[1].(*ast.InterfaceTypeDefinition); !ok {
+		t.Fatalf("Query definition[1] = %T; want *ast.InterfaceTypeDefinition", defs[1])
+	}
+
+	product := idx.LookupType("Product")
+	if product == nil {
+		t.Fatal(`LookupType("Product") = nil`)
+	}
+	if got := len(product.BaseDefinitions()); got != 0 {
+		t.Fatalf("Product BaseDefinitions() length = %d; want 0", got)
+	}
+	extensions := product.Extensions()
+	if got := len(extensions); got != 1 {
+		t.Fatalf("Product Extensions() length = %d; want 1", got)
+	}
+	if _, ok := extensions[0].(*ast.ObjectTypeExtension); !ok {
+		t.Fatalf("Product extension = %T; want *ast.ObjectTypeExtension", extensions[0])
+	}
+}
+
+func TestNewIgnoresNonTypeDefinitions(t *testing.T) {
+	doc, err := parser.Parse(`
+		schema { query: Query }
+		extend schema @tag
+		directive @tag on SCHEMA
+		query Get { viewer }
+		fragment Fields on Query { viewer }
+		type Query { viewer: String }
+	`)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	doc.Definitions = append([]ast.Definition{&ast.BadDefinition{}}, doc.Definitions...)
+
+	idx := schemaindex.New(doc)
+	if idx.LookupType("Query") == nil {
+		t.Fatal(`LookupType("Query") = nil`)
+	}
+	for _, name := range []string{"tag", "Get", "Fields"} {
+		if got := idx.LookupType(name); got != nil {
+			t.Fatalf("LookupType(%q) = %#v; want nil", name, got)
+		}
+	}
+}
+
+func TestNewNilDocumentIsEmpty(t *testing.T) {
+	idx := schemaindex.New(nil)
+	if got := idx.LookupType("Query"); got != nil {
+		t.Fatalf("LookupType(%q) = %#v; want nil", "Query", got)
+	}
+}
+
+func TestEntryDefinitionSlicesAreCopies(t *testing.T) {
+	doc := mustParseSchema(t, `
+		type Query { name: String }
+		extend type Query { age: Int }
+	`)
+
+	entry := schemaindex.New(doc).LookupType("Query")
+	if entry == nil {
+		t.Fatal(`LookupType("Query") = nil`)
+	}
+
+	baseDefs := entry.BaseDefinitions()
+	baseDefs[0] = nil
+	extensions := entry.Extensions()
+	extensions[0] = nil
+
+	if got := entry.BaseDefinitions()[0]; got == nil {
+		t.Fatal("BaseDefinitions()[0] = nil after mutating returned slice")
+	}
+	if got := entry.Extensions()[0]; got == nil {
+		t.Fatal("Extensions()[0] = nil after mutating returned slice")
+	}
+}
+
+func mustParseSchema(t *testing.T, body string) *ast.Document {
+	t.Helper()
+	doc, err := parser.ParseSchema(body)
+	if err != nil {
+		t.Fatalf("ParseSchema returned error: %v", err)
+	}
+	return doc
+}

--- a/schemaindex/index_test.go
+++ b/schemaindex/index_test.go
@@ -129,8 +129,8 @@ func TestNewRecordsExtensionsSeparatelyInSourceOrder(t *testing.T) {
 	if got := len(extensions); got != 2 {
 		t.Fatalf("Query Extensions() length = %d; want 2", got)
 	}
-	firstExt := extensions[0].(*ast.ObjectTypeExtension)
-	secondExt := extensions[1].(*ast.ObjectTypeExtension)
+	firstExt := requireObjectTypeExtension(t, extensions[0])
+	secondExt := requireObjectTypeExtension(t, extensions[1])
 	if firstExt.Fields[0].Name != "second" {
 		t.Fatalf("first Query extension field = %q; want second", firstExt.Fields[0].Name)
 	}
@@ -222,8 +222,8 @@ func TestNewPreservesDuplicateBaseDefinitionsInSourceOrder(t *testing.T) {
 	if got := len(defs); got != 2 {
 		t.Fatalf("BaseDefinitions() length = %d; want 2", got)
 	}
-	first := defs[0].(*ast.ObjectTypeDefinition)
-	second := defs[1].(*ast.ObjectTypeDefinition)
+	first := requireObjectTypeDefinition(t, defs[0])
+	second := requireObjectTypeDefinition(t, defs[1])
 	if first.Fields[0].Name != "first" {
 		t.Fatalf("first Query base definition field = %q; want first", first.Fields[0].Name)
 	}
@@ -273,7 +273,7 @@ func TestNewDoesNotValidateSchemaSemantics(t *testing.T) {
 
 func TestNewIgnoresNonTypeDefinitions(t *testing.T) {
 	doc, err := parser.Parse(`
-		schema { query: Query }
+		schema { query: Root }
 		extend schema @tag
 		directive @tag on SCHEMA
 		query Get { viewer }
@@ -289,7 +289,7 @@ func TestNewIgnoresNonTypeDefinitions(t *testing.T) {
 	if idx.LookupType("Query") == nil {
 		t.Fatal(`LookupType("Query") = nil`)
 	}
-	for _, name := range []string{"tag", "Get", "Fields"} {
+	for _, name := range []string{"Root", "tag", "Get", "Fields"} {
 		if got := idx.LookupType(name); got != nil {
 			t.Fatalf("LookupType(%q) = %#v; want nil", name, got)
 		}
@@ -314,17 +314,43 @@ func TestEntryDefinitionSlicesAreCopies(t *testing.T) {
 		t.Fatal(`LookupType("Query") = nil`)
 	}
 
+	wantBase := doc.Definitions[0]
+	wantExtension := doc.Definitions[1]
 	baseDefs := entry.BaseDefinitions()
+	if got := baseDefs[0]; got != wantBase {
+		t.Fatalf("BaseDefinitions()[0] = %T; want original parsed node %T", got, wantBase)
+	}
 	baseDefs[0] = nil
 	extensions := entry.Extensions()
+	if got := extensions[0]; got != wantExtension {
+		t.Fatalf("Extensions()[0] = %T; want original parsed node %T", got, wantExtension)
+	}
 	extensions[0] = nil
 
-	if got := entry.BaseDefinitions()[0]; got == nil {
-		t.Fatal("BaseDefinitions()[0] = nil after mutating returned slice")
+	if got := entry.BaseDefinitions()[0]; got != wantBase {
+		t.Fatalf("BaseDefinitions()[0] = %T after mutating returned slice; want original parsed node %T", got, wantBase)
 	}
-	if got := entry.Extensions()[0]; got == nil {
-		t.Fatal("Extensions()[0] = nil after mutating returned slice")
+	if got := entry.Extensions()[0]; got != wantExtension {
+		t.Fatalf("Extensions()[0] = %T after mutating returned slice; want original parsed node %T", got, wantExtension)
 	}
+}
+
+func requireObjectTypeDefinition(t *testing.T, def ast.Definition) *ast.ObjectTypeDefinition {
+	t.Helper()
+	objectDef, ok := def.(*ast.ObjectTypeDefinition)
+	if !ok {
+		t.Fatalf("definition = %T; want *ast.ObjectTypeDefinition", def)
+	}
+	return objectDef
+}
+
+func requireObjectTypeExtension(t *testing.T, def ast.Definition) *ast.ObjectTypeExtension {
+	t.Helper()
+	objectExt, ok := def.(*ast.ObjectTypeExtension)
+	if !ok {
+		t.Fatalf("extension = %T; want *ast.ObjectTypeExtension", def)
+	}
+	return objectExt
 }
 
 func mustParseSchema(t *testing.T, body string) *ast.Document {


### PR DESCRIPTION
Closes #10.

## Summary

Adds a new public `schemaindex` package for building a lightweight SDL type-definition index from a parsed `*ast.Document`.

## Implementation

- Adds `schemaindex.New(doc *ast.Document) *Index` and `LookupType(name string) *TypeEntry`.
- Indexes the six named SDL type definition forms and the six matching extension forms.
- Keeps base definitions and extensions separate while preserving source order, including duplicates and repeated extensions.
- Returns shallow copies from `BaseDefinitions()` and `Extensions()` so callers cannot mutate index internals.
- Ignores schema definitions/extensions, directive definitions, executable definitions, and recovery `BadDefinition` nodes.
- Keeps the package dependency boundary narrow: production `schemaindex` imports only `ast`.

## Docs

- Updates README usage and public package list.
- Updates AGENTS architecture notes and testing layout.
- Aligns performance grep docs with the new package and existing allowed error-formatting hits.

## Verification

- `go test ./schemaindex`
- `gofmt -l .`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `rg -n 'regexp|reflect|fmt\.Sprintf' lexer/ parser/ ast/ schemaindex/`
- `go test -run=- -bench=. -benchmem ./parser/`
- `autoreview --mode branch --base origin/main` clean: no accepted/actionable findings