### PR TITLE
Fold schema index extensions into helper accessors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ LSP can depend on AST types without dragging in the parser.
 - `ast/` - `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; concrete pointer-receiver structs for every spec production; `Source`, `Position`, `Loc` with a lazy line-start index; `BlockStringValue`, `TypeString`, `NamedTypeName`, and `DirectiveStringArg` helpers; `Walk`/`Inspect`; `SyntaxError` with the graphql-js-style snippet renderer.
 - `lexer/` - synchronous, single-token-lookahead, hand-written tokenizer. `Token` carries byte offsets plus a `Value` that is a sub-slice of source for `NAME`/`INT`/`FLOAT`. `STRING` tokens own their decoded value. `Lexer.PreserveComments` is the internal switch the parser flips for `WithComments`.
 - `parser/` - recursive descent. Public API is `Parse`, `ParseSource`, `ParseSchema`, `ParseSchemaSource`, `ParseValue`, `ParseConstValue`, `ParseType`, plus `WithRecovery()` and `WithComments()`. Everything else is unexported.
-- `schemaindex/` - small public SDL index over a parsed `*ast.Document`. `New` records the six named type definitions and six matching extension forms by name, keeps base definitions and extensions separate in source order, ignores non-type definitions, and does not validate or fold schema semantics.
+- `schemaindex/` - small public SDL index over a parsed `*ast.Document`. `New` records the six named type definitions and six matching extension forms by name, keeps base definitions and extensions separate in source order, ignores non-type definitions, and does not validate schema semantics. Object, interface, and input helper accessors expose base members followed by matching extension members without deduplicating or merging raw definitions.
 
 ### Key invariants
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,15 @@ idx := schemaindex.New(schemaDoc)
 query := idx.LookupType("Query")
 base := query.BaseDefinitions()[0].(*ast.ObjectTypeDefinition)
 ext := query.Extensions()[0].(*ast.ObjectTypeExtension)
+fields := query.ObjectFields()
 
-fmt.Println(base.Name, ext.Fields[0].Name)
+fmt.Println(base.Name, ext.Fields[0].Name, fields[1].Name)
 ```
 
 The index does not validate schema semantics, enforce duplicate-name rules, or
-fold extensions into base definitions.
+deduplicate folded members. `BaseDefinitions()` and `Extensions()` preserve raw
+parsed metadata separately; object, interface, and input helper accessors return
+base members followed by matching extension members.
 
 ### Parse a single value or type literal
 

--- a/schemaindex/index.go
+++ b/schemaindex/index.go
@@ -1,8 +1,10 @@
 // Package schemaindex indexes parsed GraphQL SDL type definitions.
 //
 // The index records top-level named type definitions and matching extensions.
-// It does not validate schema semantics, merge duplicate definitions, or fold
-// extensions into their base definitions.
+// Raw base definitions and extensions stay separate, while object, interface,
+// and input helper accessors expose base members followed by extension members.
+// It does not validate schema semantics, merge duplicate definitions, or
+// deduplicate folded members.
 package schemaindex
 
 import "github.com/brian-bell/graphql-parser/ast"
@@ -108,6 +110,91 @@ func (e *TypeEntry) BaseDefinitions() []ast.Definition {
 // entry. The AST nodes inside the returned slice are the original parsed nodes.
 func (e *TypeEntry) Extensions() []ast.Definition {
 	return copyDefinitions(e.extensions)
+}
+
+// ObjectFields returns object fields from base definitions followed by matching
+// object extensions, each in source order.
+func (e *TypeEntry) ObjectFields() ast.FieldDefinitionList {
+	var fields ast.FieldDefinitionList
+	for _, def := range e.baseDefinitions {
+		if objectDef, ok := def.(*ast.ObjectTypeDefinition); ok {
+			fields = append(fields, objectDef.Fields...)
+		}
+	}
+	for _, def := range e.extensions {
+		if objectExt, ok := def.(*ast.ObjectTypeExtension); ok {
+			fields = append(fields, objectExt.Fields...)
+		}
+	}
+	return fields
+}
+
+// ObjectInterfaces returns object implemented interfaces from base definitions
+// followed by matching object extensions, each in source order.
+func (e *TypeEntry) ObjectInterfaces() []*ast.NamedType {
+	var interfaces []*ast.NamedType
+	for _, def := range e.baseDefinitions {
+		if objectDef, ok := def.(*ast.ObjectTypeDefinition); ok {
+			interfaces = append(interfaces, objectDef.Interfaces...)
+		}
+	}
+	for _, def := range e.extensions {
+		if objectExt, ok := def.(*ast.ObjectTypeExtension); ok {
+			interfaces = append(interfaces, objectExt.Interfaces...)
+		}
+	}
+	return interfaces
+}
+
+// InterfaceInterfaces returns interface implemented interfaces from base
+// definitions followed by matching interface extensions, each in source order.
+func (e *TypeEntry) InterfaceInterfaces() []*ast.NamedType {
+	var interfaces []*ast.NamedType
+	for _, def := range e.baseDefinitions {
+		if interfaceDef, ok := def.(*ast.InterfaceTypeDefinition); ok {
+			interfaces = append(interfaces, interfaceDef.Interfaces...)
+		}
+	}
+	for _, def := range e.extensions {
+		if interfaceExt, ok := def.(*ast.InterfaceTypeExtension); ok {
+			interfaces = append(interfaces, interfaceExt.Interfaces...)
+		}
+	}
+	return interfaces
+}
+
+// InterfaceFields returns interface fields from base definitions followed by
+// matching interface extensions, each in source order.
+func (e *TypeEntry) InterfaceFields() ast.FieldDefinitionList {
+	var fields ast.FieldDefinitionList
+	for _, def := range e.baseDefinitions {
+		if interfaceDef, ok := def.(*ast.InterfaceTypeDefinition); ok {
+			fields = append(fields, interfaceDef.Fields...)
+		}
+	}
+	for _, def := range e.extensions {
+		if interfaceExt, ok := def.(*ast.InterfaceTypeExtension); ok {
+			fields = append(fields, interfaceExt.Fields...)
+		}
+	}
+	return fields
+}
+
+// InputFields returns input object fields from base definitions followed by
+// matching input object extensions, each in source order.
+func (e *TypeEntry) InputFields() ast.InputValueList {
+	var fields ast.InputValueList
+	for _, def := range e.baseDefinitions {
+		if inputDef, ok := def.(*ast.InputObjectTypeDefinition); ok {
+			fields = append(fields, inputDef.Fields...)
+		}
+	}
+	for _, def := range e.extensions {
+		if inputExt, ok := def.(*ast.InputObjectTypeExtension); ok {
+			fields = append(fields, inputExt.Fields...)
+		}
+	}
+	return fields
 }
 
 func copyDefinitions(defs []ast.Definition) []ast.Definition {

--- a/schemaindex/index_test.go
+++ b/schemaindex/index_test.go
@@ -207,6 +207,183 @@ func TestNewRecordsExtensionsSeparatelyInSourceOrder(t *testing.T) {
 	}
 }
 
+func TestTypeEntryObjectFieldsFoldBaseAndExtensions(t *testing.T) {
+	doc := mustParseSchema(t, `
+		type Query { base: String }
+		extend type Query { firstExtension: String }
+		extend type Product { id: ID }
+		extend type Query { secondExtension: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	query := idx.LookupType("Query")
+	if query == nil {
+		t.Fatal(`LookupType("Query") = nil`)
+	}
+	assertFieldNames(t, query.ObjectFields(), "base", "firstExtension", "secondExtension")
+
+	product := idx.LookupType("Product")
+	if product == nil {
+		t.Fatal(`LookupType("Product") = nil`)
+	}
+	assertFieldNames(t, product.ObjectFields(), "id")
+}
+
+func TestTypeEntryInterfacesFoldBaseAndExtensions(t *testing.T) {
+	doc := mustParseSchema(t, `
+		type User implements Node { id: ID }
+		extend type User implements Resource { resource: String }
+		interface Resource implements Node { id: ID }
+		extend interface Resource implements Named { name: String }
+		extend type Product implements Node { id: ID }
+		extend interface Entity implements Node { id: ID }
+	`)
+
+	idx := schemaindex.New(doc)
+	user := idx.LookupType("User")
+	if user == nil {
+		t.Fatal(`LookupType("User") = nil`)
+	}
+	assertNamedTypeNames(t, user.ObjectInterfaces(), "Node", "Resource")
+
+	product := idx.LookupType("Product")
+	if product == nil {
+		t.Fatal(`LookupType("Product") = nil`)
+	}
+	assertNamedTypeNames(t, product.ObjectInterfaces(), "Node")
+
+	resource := idx.LookupType("Resource")
+	if resource == nil {
+		t.Fatal(`LookupType("Resource") = nil`)
+	}
+	assertNamedTypeNames(t, resource.InterfaceInterfaces(), "Node", "Named")
+
+	entity := idx.LookupType("Entity")
+	if entity == nil {
+		t.Fatal(`LookupType("Entity") = nil`)
+	}
+	assertNamedTypeNames(t, entity.InterfaceInterfaces(), "Node")
+}
+
+func TestTypeEntryInterfaceFieldsFoldBaseAndExtensions(t *testing.T) {
+	doc := mustParseSchema(t, `
+		interface Node { id: ID! }
+		extend interface Node { createdAt: String }
+		extend interface Entity { id: ID! }
+		extend interface Node { updatedAt: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	node := idx.LookupType("Node")
+	if node == nil {
+		t.Fatal(`LookupType("Node") = nil`)
+	}
+	assertFieldNames(t, node.InterfaceFields(), "id", "createdAt", "updatedAt")
+
+	entity := idx.LookupType("Entity")
+	if entity == nil {
+		t.Fatal(`LookupType("Entity") = nil`)
+	}
+	assertFieldNames(t, entity.InterfaceFields(), "id")
+}
+
+func TestTypeEntryInputFieldsFoldBaseAndExtensions(t *testing.T) {
+	doc := mustParseSchema(t, `
+		input UserInput { id: ID }
+		extend input UserInput { name: String }
+		extend input ProductInput { sku: String }
+		extend input UserInput { email: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	userInput := idx.LookupType("UserInput")
+	if userInput == nil {
+		t.Fatal(`LookupType("UserInput") = nil`)
+	}
+	assertInputValueNames(t, userInput.InputFields(), "id", "name", "email")
+
+	productInput := idx.LookupType("ProductInput")
+	if productInput == nil {
+		t.Fatal(`LookupType("ProductInput") = nil`)
+	}
+	assertInputValueNames(t, productInput.InputFields(), "sku")
+}
+
+func TestTypeEntryDirectiveOnlyExtensionsPreserveMetadataWithoutMembers(t *testing.T) {
+	doc := mustParseSchema(t, `
+		directive @tag on OBJECT | INTERFACE | INPUT_OBJECT
+
+		type Query { base: String }
+		extend type Query @tag
+		extend type Product @tag
+
+		interface Node { id: ID! }
+		extend interface Node @tag
+		extend interface Entity @tag
+
+		input UserInput { id: ID }
+		extend input UserInput @tag
+		extend input ProductInput @tag
+	`)
+
+	idx := schemaindex.New(doc)
+	query := idx.LookupType("Query")
+	if query == nil {
+		t.Fatal(`LookupType("Query") = nil`)
+	}
+	assertFieldNames(t, query.ObjectFields(), "base")
+	if got := len(query.Extensions()); got != 1 {
+		t.Fatalf("Query Extensions() length = %d; want 1", got)
+	}
+
+	product := idx.LookupType("Product")
+	if product == nil {
+		t.Fatal(`LookupType("Product") = nil`)
+	}
+	assertFieldNames(t, product.ObjectFields())
+	if got := len(product.Extensions()); got != 1 {
+		t.Fatalf("Product Extensions() length = %d; want 1", got)
+	}
+
+	node := idx.LookupType("Node")
+	if node == nil {
+		t.Fatal(`LookupType("Node") = nil`)
+	}
+	assertFieldNames(t, node.InterfaceFields(), "id")
+	assertNamedTypeNames(t, node.InterfaceInterfaces())
+	if got := len(node.Extensions()); got != 1 {
+		t.Fatalf("Node Extensions() length = %d; want 1", got)
+	}
+
+	entity := idx.LookupType("Entity")
+	if entity == nil {
+		t.Fatal(`LookupType("Entity") = nil`)
+	}
+	assertFieldNames(t, entity.InterfaceFields())
+	assertNamedTypeNames(t, entity.InterfaceInterfaces())
+	if got := len(entity.Extensions()); got != 1 {
+		t.Fatalf("Entity Extensions() length = %d; want 1", got)
+	}
+
+	userInput := idx.LookupType("UserInput")
+	if userInput == nil {
+		t.Fatal(`LookupType("UserInput") = nil`)
+	}
+	assertInputValueNames(t, userInput.InputFields(), "id")
+	if got := len(userInput.Extensions()); got != 1 {
+		t.Fatalf("UserInput Extensions() length = %d; want 1", got)
+	}
+
+	productInput := idx.LookupType("ProductInput")
+	if productInput == nil {
+		t.Fatal(`LookupType("ProductInput") = nil`)
+	}
+	assertInputValueNames(t, productInput.InputFields())
+	if got := len(productInput.Extensions()); got != 1 {
+		t.Fatalf("ProductInput Extensions() length = %d; want 1", got)
+	}
+}
+
 func TestNewPreservesDuplicateBaseDefinitionsInSourceOrder(t *testing.T) {
 	doc := mustParseSchema(t, `
 		type Query { first: String }
@@ -335,6 +512,58 @@ func TestEntryDefinitionSlicesAreCopies(t *testing.T) {
 	}
 }
 
+func TestTypeEntryFoldedMemberSlicesAreCopies(t *testing.T) {
+	doc := mustParseSchema(t, `
+		type User implements Node { id: ID }
+		extend type User implements Resource { name: String }
+		input UserInput { id: ID }
+		extend input UserInput { name: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	user := idx.LookupType("User")
+	if user == nil {
+		t.Fatal(`LookupType("User") = nil`)
+	}
+	fields := user.ObjectFields()
+	fields[0] = nil
+	assertFieldNames(t, user.ObjectFields(), "id", "name")
+
+	interfaces := user.ObjectInterfaces()
+	interfaces[0] = nil
+	assertNamedTypeNames(t, user.ObjectInterfaces(), "Node", "Resource")
+
+	userInput := idx.LookupType("UserInput")
+	if userInput == nil {
+		t.Fatal(`LookupType("UserInput") = nil`)
+	}
+	inputFields := userInput.InputFields()
+	inputFields[0] = nil
+	assertInputValueNames(t, userInput.InputFields(), "id", "name")
+}
+
+func TestTypeEntryFoldedAccessorsIgnoreMixedKindEntries(t *testing.T) {
+	doc := mustParseSchema(t, `
+		type Shared { objectBase: String }
+		interface Shared { interfaceBase: String }
+		input Shared { inputBase: String }
+		extend type Shared implements Node { objectExtension: String }
+		extend interface Shared implements Resource { interfaceExtension: String }
+		extend input Shared { inputExtension: String }
+	`)
+
+	entry := schemaindex.New(doc).LookupType("Shared")
+	if entry == nil {
+		t.Fatal(`LookupType("Shared") = nil`)
+	}
+
+	assertFieldNames(t, entry.ObjectFields(), "objectBase", "objectExtension")
+	assertNamedTypeNames(t, entry.ObjectInterfaces(), "Node")
+	assertFieldNames(t, entry.InterfaceFields(), "interfaceBase", "interfaceExtension")
+	assertNamedTypeNames(t, entry.InterfaceInterfaces(), "Resource")
+	assertInputValueNames(t, entry.InputFields(), "inputBase", "inputExtension")
+}
+
 func requireObjectTypeDefinition(t *testing.T, def ast.Definition) *ast.ObjectTypeDefinition {
 	t.Helper()
 	objectDef, ok := def.(*ast.ObjectTypeDefinition)
@@ -351,6 +580,42 @@ func requireObjectTypeExtension(t *testing.T, def ast.Definition) *ast.ObjectTyp
 		t.Fatalf("extension = %T; want *ast.ObjectTypeExtension", def)
 	}
 	return objectExt
+}
+
+func assertFieldNames(t *testing.T, fields ast.FieldDefinitionList, names ...string) {
+	t.Helper()
+	if got := len(fields); got != len(names) {
+		t.Fatalf("field count = %d; want %d", got, len(names))
+	}
+	for i, name := range names {
+		if fields[i].Name != name {
+			t.Fatalf("field[%d].Name = %q; want %q", i, fields[i].Name, name)
+		}
+	}
+}
+
+func assertNamedTypeNames(t *testing.T, types []*ast.NamedType, names ...string) {
+	t.Helper()
+	if got := len(types); got != len(names) {
+		t.Fatalf("named type count = %d; want %d", got, len(names))
+	}
+	for i, name := range names {
+		if types[i].Name != name {
+			t.Fatalf("namedType[%d].Name = %q; want %q", i, types[i].Name, name)
+		}
+	}
+}
+
+func assertInputValueNames(t *testing.T, values ast.InputValueList, names ...string) {
+	t.Helper()
+	if got := len(values); got != len(names) {
+		t.Fatalf("input value count = %d; want %d", got, len(names))
+	}
+	for i, name := range names {
+		if values[i].Name != name {
+			t.Fatalf("inputValue[%d].Name = %q; want %q", i, values[i].Name, name)
+		}
+	}
 }
 
 func mustParseSchema(t *testing.T, body string) *ast.Document {

--- a/schemaindex/index_test.go
+++ b/schemaindex/index_test.go
@@ -516,6 +516,8 @@ func TestTypeEntryFoldedMemberSlicesAreCopies(t *testing.T) {
 	doc := mustParseSchema(t, `
 		type User implements Node { id: ID }
 		extend type User implements Resource { name: String }
+		interface Entity implements Node { id: ID }
+		extend interface Entity implements Resource { name: String }
 		input UserInput { id: ID }
 		extend input UserInput { name: String }
 	`)
@@ -532,6 +534,18 @@ func TestTypeEntryFoldedMemberSlicesAreCopies(t *testing.T) {
 	interfaces := user.ObjectInterfaces()
 	interfaces[0] = nil
 	assertNamedTypeNames(t, user.ObjectInterfaces(), "Node", "Resource")
+
+	entity := idx.LookupType("Entity")
+	if entity == nil {
+		t.Fatal(`LookupType("Entity") = nil`)
+	}
+	interfaceFields := entity.InterfaceFields()
+	interfaceFields[0] = nil
+	assertFieldNames(t, entity.InterfaceFields(), "id", "name")
+
+	interfaceInterfaces := entity.InterfaceInterfaces()
+	interfaceInterfaces[0] = nil
+	assertNamedTypeNames(t, entity.InterfaceInterfaces(), "Node", "Resource")
 
 	userInput := idx.LookupType("UserInput")
 	if userInput == nil {


### PR DESCRIPTION
## Summary
- Fold object, interface, and input object extensions into schemaindex helper accessors in source order
- Keep base definitions and raw extension definitions separate while exposing combined member views
- Add coverage for fields, interfaces, directives, and input fields across base and extension definitions
- Refresh README/API notes for the folded helper behavior

## Verification
- gofmt -l .
- go test ./...
- go vet ./...