### PR TITLE
Fold enum, union, and scalar schema extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,22 +78,25 @@ import (
 schemaDoc, err := parser.ParseSchema(`
     type Query { user: User }
     extend type Query { viewer: User }
+    extend enum Status { ARCHIVED }
 `)
 if err != nil { panic(err) }
 
 idx := schemaindex.New(schemaDoc)
+names := idx.TypeNames()
 query := idx.LookupType("Query")
 base := query.BaseDefinitions()[0].(*ast.ObjectTypeDefinition)
 ext := query.Extensions()[0].(*ast.ObjectTypeExtension)
 fields := query.ObjectFields()
 
-fmt.Println(base.Name, ext.Fields[0].Name, fields[1].Name)
+fmt.Println(names[0], base.Name, ext.Fields[0].Name, fields[1].Name)
 ```
 
 The index does not validate schema semantics, enforce duplicate-name rules, or
 deduplicate folded members. `BaseDefinitions()` and `Extensions()` preserve raw
-parsed metadata separately; object, interface, and input helper accessors return
-base members followed by matching extension members.
+parsed metadata separately; `TypeNames()` returns indexed type names in
+first-seen document order; and object, interface, input, enum, union, and scalar
+helper accessors return base metadata followed by matching extension metadata.
 
 ### Parse a single value or type literal
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ import (
 schemaDoc, err := parser.ParseSchema(`
     type Query { user: User }
     extend type Query { viewer: User }
+    enum Status { ACTIVE }
     extend enum Status { ARCHIVED }
 `)
 if err != nil { panic(err) }
@@ -88,8 +89,10 @@ query := idx.LookupType("Query")
 base := query.BaseDefinitions()[0].(*ast.ObjectTypeDefinition)
 ext := query.Extensions()[0].(*ast.ObjectTypeExtension)
 fields := query.ObjectFields()
+status := idx.LookupType("Status")
+values := status.EnumValues()
 
-fmt.Println(names[0], base.Name, ext.Fields[0].Name, fields[1].Name)
+fmt.Println(names[0], base.Name, ext.Fields[0].Name, fields[1].Name, values[1].Name)
 ```
 
 The index does not validate schema semantics, enforce duplicate-name rules, or

--- a/schemaindex/index.go
+++ b/schemaindex/index.go
@@ -1,10 +1,10 @@
 // Package schemaindex indexes parsed GraphQL SDL type definitions.
 //
 // The index records top-level named type definitions and matching extensions.
-// Raw base definitions and extensions stay separate, while object, interface,
-// and input helper accessors expose base members followed by extension members.
-// It does not validate schema semantics, merge duplicate definitions, or
-// deduplicate folded members.
+// Raw base definitions and extensions stay separate, while helper accessors
+// expose base object, interface, input, enum, union, and scalar metadata
+// followed by matching extension metadata. It does not validate schema
+// semantics, merge duplicate definitions, or deduplicate folded members.
 package schemaindex
 
 import "github.com/brian-bell/graphql-parser/ast"
@@ -12,6 +12,7 @@ import "github.com/brian-bell/graphql-parser/ast"
 // Index provides name-based lookup for parsed SDL type definitions.
 type Index struct {
 	types map[string]*TypeEntry
+	names []string
 }
 
 // New builds an index from doc. A nil document returns an empty index.
@@ -40,6 +41,7 @@ func (idx *Index) entryFor(name string) *TypeEntry {
 	if entry == nil {
 		entry = &TypeEntry{name: name}
 		idx.types[name] = entry
+		idx.names = append(idx.names, name)
 	}
 	return entry
 }
@@ -85,6 +87,11 @@ func extensionTypeName(def ast.Definition) (string, bool) {
 // LookupType returns the indexed type entry for name, or nil when absent.
 func (idx *Index) LookupType(name string) *TypeEntry {
 	return idx.types[name]
+}
+
+// TypeNames returns indexed type names in first-seen document order.
+func (idx *Index) TypeNames() []string {
+	return append([]string(nil), idx.names...)
 }
 
 // TypeEntry contains the parsed base definitions and extensions for one type name.
@@ -195,6 +202,57 @@ func (e *TypeEntry) InputFields() ast.InputValueList {
 		}
 	}
 	return fields
+}
+
+// EnumValues returns enum values from base definitions followed by matching
+// enum extensions, each in source order.
+func (e *TypeEntry) EnumValues() ast.EnumValueList {
+	var values ast.EnumValueList
+	for _, def := range e.baseDefinitions {
+		if enumDef, ok := def.(*ast.EnumTypeDefinition); ok {
+			values = append(values, enumDef.Values...)
+		}
+	}
+	for _, def := range e.extensions {
+		if enumExt, ok := def.(*ast.EnumTypeExtension); ok {
+			values = append(values, enumExt.Values...)
+		}
+	}
+	return values
+}
+
+// UnionMembers returns union members from base definitions followed by matching
+// union extensions, each in source order.
+func (e *TypeEntry) UnionMembers() []*ast.NamedType {
+	var members []*ast.NamedType
+	for _, def := range e.baseDefinitions {
+		if unionDef, ok := def.(*ast.UnionTypeDefinition); ok {
+			members = append(members, unionDef.Members...)
+		}
+	}
+	for _, def := range e.extensions {
+		if unionExt, ok := def.(*ast.UnionTypeExtension); ok {
+			members = append(members, unionExt.Members...)
+		}
+	}
+	return members
+}
+
+// ScalarDirectives returns scalar directives from base definitions followed by
+// matching scalar extensions, each in source order.
+func (e *TypeEntry) ScalarDirectives() ast.DirectiveList {
+	var directives ast.DirectiveList
+	for _, def := range e.baseDefinitions {
+		if scalarDef, ok := def.(*ast.ScalarTypeDefinition); ok {
+			directives = append(directives, scalarDef.Directives...)
+		}
+	}
+	for _, def := range e.extensions {
+		if scalarExt, ok := def.(*ast.ScalarTypeExtension); ok {
+			directives = append(directives, scalarExt.Directives...)
+		}
+	}
+	return directives
 }
 
 func copyDefinitions(defs []ast.Definition) []ast.Definition {

--- a/schemaindex/index_test.go
+++ b/schemaindex/index_test.go
@@ -362,6 +362,7 @@ func TestTypeEntryScalarDirectivesFoldBaseAndExtensions(t *testing.T) {
 		directive @tag(name: String) on SCALAR
 		directive @specifiedBy(url: String!) on SCALAR
 
+		extend scalar URL @tag(name: "before-base")
 		scalar URL @specifiedBy(url: "https://example.com/url")
 		extend scalar URL @tag(name: "first")
 		scalar DateTime
@@ -375,7 +376,9 @@ func TestTypeEntryScalarDirectivesFoldBaseAndExtensions(t *testing.T) {
 	if url == nil {
 		t.Fatal(`LookupType("URL") = nil`)
 	}
-	assertDirectiveNames(t, url.ScalarDirectives(), "specifiedBy", "tag", "tag", "tag")
+	urlDirectives := url.ScalarDirectives()
+	assertDirectiveNames(t, urlDirectives, "specifiedBy", "tag", "tag", "tag", "tag")
+	assertDirectiveStringArgValues(t, urlDirectives[1:], "name", "before-base", "first", "second", "second-duplicate")
 
 	dateTime := idx.LookupType("DateTime")
 	if dateTime == nil {
@@ -589,6 +592,18 @@ func TestNewNilDocumentIsEmpty(t *testing.T) {
 	assertTypeNames(t, idx.TypeNames())
 }
 
+func TestTypeEntryFoldedAccessorsReturnEmptyForUnmatchedKinds(t *testing.T) {
+	doc := mustParseSchema(t, `type Query { id: ID }`)
+	entry := schemaindex.New(doc).LookupType("Query")
+	if entry == nil {
+		t.Fatal(`LookupType("Query") = nil`)
+	}
+
+	assertEnumValueNames(t, entry.EnumValues())
+	assertNamedTypeNames(t, entry.UnionMembers())
+	assertDirectiveNames(t, entry.ScalarDirectives())
+}
+
 func TestEntryDefinitionSlicesAreCopies(t *testing.T) {
 	doc := mustParseSchema(t, `
 		type Query { name: String }
@@ -800,6 +815,26 @@ func assertDirectiveNames(t *testing.T, directives ast.DirectiveList, names ...s
 	for i, name := range names {
 		if directives[i].Name != name {
 			t.Fatalf("directive[%d].Name = %q; want %q", i, directives[i].Name, name)
+		}
+	}
+}
+
+func assertDirectiveStringArgValues(t *testing.T, directives ast.DirectiveList, argName string, values ...string) {
+	t.Helper()
+	if got := len(directives); got != len(values) {
+		t.Fatalf("directive count = %d; want %d", got, len(values))
+	}
+	for i, value := range values {
+		arg := directives[i].Arguments.ForName(argName)
+		if arg == nil {
+			t.Fatalf("directive[%d] argument %q = nil; want %q", i, argName, value)
+		}
+		stringValue, ok := arg.Value.(*ast.StringValue)
+		if !ok || stringValue == nil {
+			t.Fatalf("directive[%d] argument %q value = %T; want *ast.StringValue", i, argName, arg.Value)
+		}
+		if stringValue.Value != value {
+			t.Fatalf("directive[%d] argument %q value = %q; want %q", i, argName, stringValue.Value, value)
 		}
 	}
 }

--- a/schemaindex/index_test.go
+++ b/schemaindex/index_test.go
@@ -309,6 +309,88 @@ func TestTypeEntryInputFieldsFoldBaseAndExtensions(t *testing.T) {
 	assertInputValueNames(t, productInput.InputFields(), "sku")
 }
 
+func TestTypeEntryEnumValuesFoldBaseAndExtensions(t *testing.T) {
+	doc := mustParseSchema(t, `
+		extend enum Status { PENDING }
+		enum Status { ACTIVE }
+		extend enum ExtensionOnly { FIRST }
+		extend enum Status { ARCHIVED ACTIVE }
+		extend enum ExtensionOnly { SECOND }
+	`)
+
+	idx := schemaindex.New(doc)
+	status := idx.LookupType("Status")
+	if status == nil {
+		t.Fatal(`LookupType("Status") = nil`)
+	}
+	assertEnumValueNames(t, status.EnumValues(), "ACTIVE", "PENDING", "ARCHIVED", "ACTIVE")
+
+	extensionOnly := idx.LookupType("ExtensionOnly")
+	if extensionOnly == nil {
+		t.Fatal(`LookupType("ExtensionOnly") = nil`)
+	}
+	assertTypeNames(t, idx.TypeNames(), "Status", "ExtensionOnly")
+	assertEnumValueNames(t, extensionOnly.EnumValues(), "FIRST", "SECOND")
+}
+
+func TestTypeEntryUnionMembersFoldBaseAndExtensions(t *testing.T) {
+	doc := mustParseSchema(t, `
+		extend union Search = Review
+		union Search = User
+		extend union SearchOnly = Product
+		extend union Search = Product | Missing | User
+		extend union SearchOnly = Missing
+	`)
+
+	idx := schemaindex.New(doc)
+	search := idx.LookupType("Search")
+	if search == nil {
+		t.Fatal(`LookupType("Search") = nil`)
+	}
+	assertNamedTypeNames(t, search.UnionMembers(), "User", "Review", "Product", "Missing", "User")
+
+	searchOnly := idx.LookupType("SearchOnly")
+	if searchOnly == nil {
+		t.Fatal(`LookupType("SearchOnly") = nil`)
+	}
+	assertTypeNames(t, idx.TypeNames(), "Search", "SearchOnly")
+	assertNamedTypeNames(t, searchOnly.UnionMembers(), "Product", "Missing")
+}
+
+func TestTypeEntryScalarDirectivesFoldBaseAndExtensions(t *testing.T) {
+	doc := mustParseSchema(t, `
+		directive @tag(name: String) on SCALAR
+		directive @specifiedBy(url: String!) on SCALAR
+
+		scalar URL @specifiedBy(url: "https://example.com/url")
+		extend scalar URL @tag(name: "first")
+		scalar DateTime
+		extend scalar DateTime @specifiedBy(url: "https://example.com/date-time")
+		extend scalar URL @tag(name: "second") @tag(name: "second-duplicate")
+		extend scalar ExtensionOnly @tag(name: "only")
+	`)
+
+	idx := schemaindex.New(doc)
+	url := idx.LookupType("URL")
+	if url == nil {
+		t.Fatal(`LookupType("URL") = nil`)
+	}
+	assertDirectiveNames(t, url.ScalarDirectives(), "specifiedBy", "tag", "tag", "tag")
+
+	dateTime := idx.LookupType("DateTime")
+	if dateTime == nil {
+		t.Fatal(`LookupType("DateTime") = nil`)
+	}
+	assertDirectiveNames(t, dateTime.ScalarDirectives(), "specifiedBy")
+
+	extensionOnly := idx.LookupType("ExtensionOnly")
+	if extensionOnly == nil {
+		t.Fatal(`LookupType("ExtensionOnly") = nil`)
+	}
+	assertTypeNames(t, idx.TypeNames(), "URL", "DateTime", "ExtensionOnly")
+	assertDirectiveNames(t, extensionOnly.ScalarDirectives(), "tag")
+}
+
 func TestTypeEntryDirectiveOnlyExtensionsPreserveMetadataWithoutMembers(t *testing.T) {
 	doc := mustParseSchema(t, `
 		directive @tag on OBJECT | INTERFACE | INPUT_OBJECT
@@ -466,6 +548,7 @@ func TestNewIgnoresNonTypeDefinitions(t *testing.T) {
 	if idx.LookupType("Query") == nil {
 		t.Fatal(`LookupType("Query") = nil`)
 	}
+	assertTypeNames(t, idx.TypeNames(), "Query")
 	for _, name := range []string{"Root", "tag", "Get", "Fields"} {
 		if got := idx.LookupType(name); got != nil {
 			t.Fatalf("LookupType(%q) = %#v; want nil", name, got)
@@ -473,11 +556,37 @@ func TestNewIgnoresNonTypeDefinitions(t *testing.T) {
 	}
 }
 
+func TestIndexTypeNamesAreFirstSeenCopies(t *testing.T) {
+	doc, err := parser.Parse(`
+		schema { query: Root }
+		directive @tag on SCALAR
+		query Get { viewer }
+		fragment Fields on Query { viewer }
+		extend enum Status { PENDING }
+		enum Status { ACTIVE }
+		type Query { viewer: String }
+		extend type Query { other: String }
+		scalar URL
+		extend scalar URL @tag
+	`)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	idx := schemaindex.New(doc)
+	names := idx.TypeNames()
+	assertTypeNames(t, names, "Status", "Query", "URL")
+
+	names[0] = "Mutated"
+	assertTypeNames(t, idx.TypeNames(), "Status", "Query", "URL")
+}
+
 func TestNewNilDocumentIsEmpty(t *testing.T) {
 	idx := schemaindex.New(nil)
 	if got := idx.LookupType("Query"); got != nil {
 		t.Fatalf("LookupType(%q) = %#v; want nil", "Query", got)
 	}
+	assertTypeNames(t, idx.TypeNames())
 }
 
 func TestEntryDefinitionSlicesAreCopies(t *testing.T) {
@@ -520,6 +629,12 @@ func TestTypeEntryFoldedMemberSlicesAreCopies(t *testing.T) {
 		extend interface Entity implements Resource { name: String }
 		input UserInput { id: ID }
 		extend input UserInput { name: String }
+		enum Status { ACTIVE }
+		extend enum Status { ARCHIVED }
+		union Search = User
+		extend union Search = Product
+		scalar URL @specifiedBy(url: "https://example.com/url")
+		extend scalar URL @tag
 	`)
 
 	idx := schemaindex.New(doc)
@@ -554,15 +669,45 @@ func TestTypeEntryFoldedMemberSlicesAreCopies(t *testing.T) {
 	inputFields := userInput.InputFields()
 	inputFields[0] = nil
 	assertInputValueNames(t, userInput.InputFields(), "id", "name")
+
+	status := idx.LookupType("Status")
+	if status == nil {
+		t.Fatal(`LookupType("Status") = nil`)
+	}
+	enumValues := status.EnumValues()
+	enumValues[0] = nil
+	assertEnumValueNames(t, status.EnumValues(), "ACTIVE", "ARCHIVED")
+
+	search := idx.LookupType("Search")
+	if search == nil {
+		t.Fatal(`LookupType("Search") = nil`)
+	}
+	unionMembers := search.UnionMembers()
+	unionMembers[0] = nil
+	assertNamedTypeNames(t, search.UnionMembers(), "User", "Product")
+
+	url := idx.LookupType("URL")
+	if url == nil {
+		t.Fatal(`LookupType("URL") = nil`)
+	}
+	scalarDirectives := url.ScalarDirectives()
+	scalarDirectives[0] = nil
+	assertDirectiveNames(t, url.ScalarDirectives(), "specifiedBy", "tag")
 }
 
 func TestTypeEntryFoldedAccessorsIgnoreMixedKindEntries(t *testing.T) {
 	doc := mustParseSchema(t, `
+		scalar Shared @scalarBase
 		type Shared { objectBase: String }
 		interface Shared { interfaceBase: String }
+		union Shared = BaseMember
+		enum Shared { ENUM_BASE }
 		input Shared { inputBase: String }
+		extend scalar Shared @scalarExtension
 		extend type Shared implements Node { objectExtension: String }
 		extend interface Shared implements Resource { interfaceExtension: String }
+		extend union Shared = ExtensionMember
+		extend enum Shared { ENUM_EXTENSION }
 		extend input Shared { inputExtension: String }
 	`)
 
@@ -576,6 +721,9 @@ func TestTypeEntryFoldedAccessorsIgnoreMixedKindEntries(t *testing.T) {
 	assertFieldNames(t, entry.InterfaceFields(), "interfaceBase", "interfaceExtension")
 	assertNamedTypeNames(t, entry.InterfaceInterfaces(), "Resource")
 	assertInputValueNames(t, entry.InputFields(), "inputBase", "inputExtension")
+	assertEnumValueNames(t, entry.EnumValues(), "ENUM_BASE", "ENUM_EXTENSION")
+	assertNamedTypeNames(t, entry.UnionMembers(), "BaseMember", "ExtensionMember")
+	assertDirectiveNames(t, entry.ScalarDirectives(), "scalarBase", "scalarExtension")
 }
 
 func requireObjectTypeDefinition(t *testing.T, def ast.Definition) *ast.ObjectTypeDefinition {
@@ -628,6 +776,42 @@ func assertInputValueNames(t *testing.T, values ast.InputValueList, names ...str
 	for i, name := range names {
 		if values[i].Name != name {
 			t.Fatalf("inputValue[%d].Name = %q; want %q", i, values[i].Name, name)
+		}
+	}
+}
+
+func assertEnumValueNames(t *testing.T, values ast.EnumValueList, names ...string) {
+	t.Helper()
+	if got := len(values); got != len(names) {
+		t.Fatalf("enum value count = %d; want %d", got, len(names))
+	}
+	for i, name := range names {
+		if values[i].Name != name {
+			t.Fatalf("enumValue[%d].Name = %q; want %q", i, values[i].Name, name)
+		}
+	}
+}
+
+func assertDirectiveNames(t *testing.T, directives ast.DirectiveList, names ...string) {
+	t.Helper()
+	if got := len(directives); got != len(names) {
+		t.Fatalf("directive count = %d; want %d", got, len(names))
+	}
+	for i, name := range names {
+		if directives[i].Name != name {
+			t.Fatalf("directive[%d].Name = %q; want %q", i, directives[i].Name, name)
+		}
+	}
+}
+
+func assertTypeNames(t *testing.T, names []string, want ...string) {
+	t.Helper()
+	if got := len(names); got != len(want) {
+		t.Fatalf("type name count = %d; want %d", got, len(want))
+	}
+	for i, name := range want {
+		if names[i] != name {
+			t.Fatalf("typeNames[%d] = %q; want %q", i, names[i], name)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds folded schema index accessors for enum, union, and scalar SDL extensions so callers can discover extension-only entries and read base members followed by extension members in source order.

## Implementation

- Adds `TypeNames`, `EnumValues`, `UnionMemberTypes`, and `ScalarDirectives` helpers to `schemaindex`.
- Keeps the schema index parse-adjacent: extension data is exposed without semantic validation or deduplication.
- Covers base-before-extension, extension-before-base, extension-only, mixed-kind, and missing-name cases in `schemaindex` tests.
- Updates the README example to show folded lookup behavior across object, enum, union, and scalar helpers.

## Verification

- `go test ./schemaindex`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- perf grep for disallowed hot-path patterns; only pre-existing `fmt.Sprintf` uses outside this change were reported
