### PR TITLE
Add schema root operation lookups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ LSP can depend on AST types without dragging in the parser.
 - `ast/` - `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; concrete pointer-receiver structs for every spec production; `Source`, `Position`, `Loc` with a lazy line-start index; `BlockStringValue`, `TypeString`, `NamedTypeName`, and `DirectiveStringArg` helpers; `Walk`/`Inspect`; `SyntaxError` with the graphql-js-style snippet renderer.
 - `lexer/` - synchronous, single-token-lookahead, hand-written tokenizer. `Token` carries byte offsets plus a `Value` that is a sub-slice of source for `NAME`/`INT`/`FLOAT`. `STRING` tokens own their decoded value. `Lexer.PreserveComments` is the internal switch the parser flips for `WithComments`.
 - `parser/` - recursive descent. Public API is `Parse`, `ParseSource`, `ParseSchema`, `ParseSchemaSource`, `ParseValue`, `ParseConstValue`, `ParseType`, plus `WithRecovery()` and `WithComments()`. Everything else is unexported.
-- `schemaindex/` - small public SDL index over a parsed `*ast.Document`. `New` records the six named type definitions and six matching extension forms by name, keeps base definitions and extensions separate in source order, ignores non-type definitions, and does not validate schema semantics. Object, interface, and input helper accessors expose base members followed by matching extension members without deduplicating or merging raw definitions.
+- `schemaindex/` - small public SDL index over a parsed `*ast.Document`. `New` records the six named type definitions and six matching extension forms by name, keeps base definitions and extensions separate in source order, ignores non-type definitions, and does not validate schema semantics. Object, interface, input, enum, union, and scalar helper accessors expose base members followed by matching extension members without deduplicating or merging raw definitions. `LookupQueryRoot`/`LookupMutationRoot`/`LookupSubscriptionRoot` resolve `schema { ... }` and `extend schema` operation roots (last declaration in source order wins) through indexed type entries.
 
 ### Key invariants
 
@@ -45,6 +45,7 @@ LSP can depend on AST types without dragging in the parser.
 - `Source` must not be copied after first use because it lazily builds a line-start index under `sync.Once`. Always pass `*Source`.
 - Default mode is fail-fast and corpus-conformant. `Bad*` nodes never appear unless `WithRecovery()` is set. Comments fields are nil unless `WithComments()` is set. Both options must be byte-additive; `comments_test.go` includes a comments-off invariance test.
 - `ParseSchema` and `ParseSchemaSource` reuse the normal document parser, then reject top-level `*ast.OperationDefinition` and `*ast.FragmentDefinition`. Do not fork the grammar for schema-only parsing.
+- Root operation lookup is deliberately asymmetric: `LookupQueryRoot` falls back to the `Query`-named type when no explicit root is declared, but `LookupMutationRoot`/`LookupSubscriptionRoot` report absence (`nil`) rather than defaulting to `Mutation`/`Subscription`. This matches issue #13's acceptance criteria; do not "fix" it as a bug. Whether to extend the SDL default-name fallback to mutation/subscription is tracked in issue #22.
 
 ### Recovery (`WithRecovery`)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ import (
 )
 
 schemaDoc, err := parser.ParseSchema(`
+    schema { query: Query mutation: Mutation }
     type Query { user: User }
+    type Mutation { updateUser: User }
     extend type Query { viewer: User }
     enum Status { ACTIVE }
     extend enum Status { ARCHIVED }
@@ -86,13 +88,15 @@ if err != nil { panic(err) }
 idx := schemaindex.New(schemaDoc)
 names := idx.TypeNames()
 query := idx.LookupType("Query")
+queryRoot := idx.LookupQueryRoot()
+mutationRoot := idx.LookupMutationRoot()
 base := query.BaseDefinitions()[0].(*ast.ObjectTypeDefinition)
 ext := query.Extensions()[0].(*ast.ObjectTypeExtension)
 fields := query.ObjectFields()
 status := idx.LookupType("Status")
 values := status.EnumValues()
 
-fmt.Println(names[0], base.Name, ext.Fields[0].Name, fields[1].Name, values[1].Name)
+fmt.Println(names[0], queryRoot.Name(), mutationRoot.Name(), base.Name, ext.Fields[0].Name, fields[1].Name, values[1].Name)
 ```
 
 The index does not validate schema semantics, enforce duplicate-name rules, or
@@ -100,6 +104,10 @@ deduplicate folded members. `BaseDefinitions()` and `Extensions()` preserve raw
 parsed metadata separately; `TypeNames()` returns indexed type names in
 first-seen document order; and object, interface, input, enum, union, and scalar
 helper accessors return base metadata followed by matching extension metadata.
+`LookupQueryRoot()`, `LookupMutationRoot()`, and `LookupSubscriptionRoot()`
+resolve explicit schema root operation declarations through indexed type
+entries; query lookup falls back to `Query` when no explicit query root is
+declared.
 
 ### Parse a single value or type literal
 

--- a/schemaindex/index.go
+++ b/schemaindex/index.go
@@ -3,21 +3,28 @@
 // The index records top-level named type definitions and matching extensions.
 // Raw base definitions and extensions stay separate, while helper accessors
 // expose base object, interface, input, enum, union, and scalar metadata
-// followed by matching extension metadata. It does not validate schema
-// semantics, merge duplicate definitions, or deduplicate folded members.
+// followed by matching extension metadata. It also records schema root
+// operation declarations for query, mutation, and subscription lookup. It does
+// not validate schema semantics, merge duplicate definitions, or deduplicate
+// folded members.
 package schemaindex
 
 import "github.com/brian-bell/graphql-parser/ast"
 
-// Index provides name-based lookup for parsed SDL type definitions.
+// Index provides name-based lookup for parsed SDL type definitions and schema
+// root operation types.
 type Index struct {
-	types map[string]*TypeEntry
-	names []string
+	types              map[string]*TypeEntry
+	names              []string
+	rootOperationTypes map[ast.OperationType]string
 }
 
 // New builds an index from doc. A nil document returns an empty index.
 func New(doc *ast.Document) *Index {
-	idx := &Index{types: make(map[string]*TypeEntry)}
+	idx := &Index{
+		types:              make(map[string]*TypeEntry),
+		rootOperationTypes: make(map[ast.OperationType]string),
+	}
 	if doc == nil {
 		return idx
 	}
@@ -31,7 +38,10 @@ func New(doc *ast.Document) *Index {
 		if name, ok := extensionTypeName(def); ok {
 			entry := idx.entryFor(name)
 			entry.extensions = append(entry.extensions, def)
+			continue
 		}
+
+		idx.recordRootOperationTypes(def)
 	}
 	return idx
 }
@@ -87,6 +97,52 @@ func extensionTypeName(def ast.Definition) (string, bool) {
 // LookupType returns the indexed type entry for name, or nil when absent.
 func (idx *Index) LookupType(name string) *TypeEntry {
 	return idx.types[name]
+}
+
+// LookupQueryRoot returns the indexed query root type entry, or nil when absent.
+func (idx *Index) LookupQueryRoot() *TypeEntry {
+	if root := idx.lookupRootOperationType(ast.OperationQuery); root != nil {
+		return root
+	}
+	if _, ok := idx.rootOperationTypes[ast.OperationQuery]; ok {
+		return nil
+	}
+	return idx.LookupType("Query")
+}
+
+// LookupMutationRoot returns the indexed mutation root type entry, or nil when absent.
+func (idx *Index) LookupMutationRoot() *TypeEntry {
+	return idx.lookupRootOperationType(ast.OperationMutation)
+}
+
+// LookupSubscriptionRoot returns the indexed subscription root type entry, or nil when absent.
+func (idx *Index) LookupSubscriptionRoot() *TypeEntry {
+	return idx.lookupRootOperationType(ast.OperationSubscription)
+}
+
+func (idx *Index) recordRootOperationTypes(def ast.Definition) {
+	var operationTypes []*ast.OperationTypeDefinition
+	switch d := def.(type) {
+	case *ast.SchemaDefinition:
+		operationTypes = d.OperationTypes
+	case *ast.SchemaExtension:
+		operationTypes = d.OperationTypes
+	default:
+		return
+	}
+	for _, operationType := range operationTypes {
+		if operationType.Type != nil {
+			idx.rootOperationTypes[operationType.Operation] = operationType.Type.Name
+		}
+	}
+}
+
+func (idx *Index) lookupRootOperationType(operation ast.OperationType) *TypeEntry {
+	name, ok := idx.rootOperationTypes[operation]
+	if !ok {
+		return nil
+	}
+	return idx.LookupType(name)
 }
 
 // TypeNames returns indexed type names in first-seen document order.

--- a/schemaindex/index_test.go
+++ b/schemaindex/index_test.go
@@ -533,6 +533,148 @@ func TestNewDoesNotValidateSchemaSemantics(t *testing.T) {
 	}
 }
 
+func TestIndexLookupQueryRootUsesExplicitSchemaDefinitionRoot(t *testing.T) {
+	doc := mustParseSchema(t, `
+		schema { query: RootQuery }
+		type Query { default: String }
+		type RootQuery { explicit: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	root := idx.LookupQueryRoot()
+	if root == nil {
+		t.Fatal("LookupQueryRoot() = nil")
+	}
+	if root.Name() != "RootQuery" {
+		t.Fatalf("LookupQueryRoot().Name() = %q; want RootQuery", root.Name())
+	}
+	if root == idx.LookupType("Query") {
+		t.Fatal(`LookupQueryRoot() returned LookupType("Query"); want explicit RootQuery entry`)
+	}
+}
+
+func TestIndexLookupQueryRootFallsBackToQueryOnlyWithoutExplicitRoot(t *testing.T) {
+	doc := mustParseSchema(t, `type Query { default: String }`)
+
+	idx := schemaindex.New(doc)
+	root := idx.LookupQueryRoot()
+	if root == nil {
+		t.Fatal("LookupQueryRoot() = nil")
+	}
+	if root.Name() != "Query" {
+		t.Fatalf("LookupQueryRoot().Name() = %q; want Query", root.Name())
+	}
+
+	missingExplicitDoc := mustParseSchema(t, `
+		schema { query: MissingQuery }
+		type Query { default: String }
+	`)
+	missingExplicit := schemaindex.New(missingExplicitDoc)
+	if got := missingExplicit.LookupQueryRoot(); got != nil {
+		t.Fatalf("LookupQueryRoot() with missing explicit root = %q; want nil", got.Name())
+	}
+}
+
+func TestIndexLookupMutationAndSubscriptionRootsUseExplicitSchemaDefinitionRoots(t *testing.T) {
+	doc := mustParseSchema(t, `
+		schema {
+			mutation: RootMutation
+			subscription: RootSubscription
+		}
+		type RootMutation { change: String }
+		type RootSubscription { changed: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	mutation := idx.LookupMutationRoot()
+	if mutation == nil {
+		t.Fatal("LookupMutationRoot() = nil")
+	}
+	if mutation.Name() != "RootMutation" {
+		t.Fatalf("LookupMutationRoot().Name() = %q; want RootMutation", mutation.Name())
+	}
+	subscription := idx.LookupSubscriptionRoot()
+	if subscription == nil {
+		t.Fatal("LookupSubscriptionRoot() = nil")
+	}
+	if subscription.Name() != "RootSubscription" {
+		t.Fatalf("LookupSubscriptionRoot().Name() = %q; want RootSubscription", subscription.Name())
+	}
+}
+
+func TestIndexLookupMutationAndSubscriptionRootsReturnNilWhenAbsent(t *testing.T) {
+	idx := schemaindex.New(mustParseSchema(t, `type Query { default: String }`))
+
+	if got := idx.LookupMutationRoot(); got != nil {
+		t.Fatalf("LookupMutationRoot() = %q; want nil", got.Name())
+	}
+	if got := idx.LookupSubscriptionRoot(); got != nil {
+		t.Fatalf("LookupSubscriptionRoot() = %q; want nil", got.Name())
+	}
+}
+
+func TestIndexLookupRootsUseSchemaExtensionRoots(t *testing.T) {
+	doc := mustParseSchema(t, `
+		extend schema {
+			query: RootQuery
+			mutation: RootMutation
+		}
+		type Query { default: String }
+		type RootQuery { explicit: String }
+		type RootMutation { change: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	query := idx.LookupQueryRoot()
+	if query == nil {
+		t.Fatal("LookupQueryRoot() = nil")
+	}
+	if query.Name() != "RootQuery" {
+		t.Fatalf("LookupQueryRoot().Name() = %q; want RootQuery", query.Name())
+	}
+	mutation := idx.LookupMutationRoot()
+	if mutation == nil {
+		t.Fatal("LookupMutationRoot() = nil")
+	}
+	if mutation.Name() != "RootMutation" {
+		t.Fatalf("LookupMutationRoot().Name() = %q; want RootMutation", mutation.Name())
+	}
+}
+
+func TestIndexLookupRootDeclarationsUseLastSourceOrderEntry(t *testing.T) {
+	doc := mustParseSchema(t, `
+		schema {
+			query: FirstQuery
+			mutation: FirstMutation
+		}
+		extend schema {
+			query: SecondQuery
+			mutation: SecondMutation
+		}
+		extend schema {
+			subscription: FirstSubscription
+			subscription: SecondSubscription
+		}
+		type FirstQuery { field: String }
+		type SecondQuery { field: String }
+		type FirstMutation { field: String }
+		type SecondMutation { field: String }
+		type FirstSubscription { field: String }
+		type SecondSubscription { field: String }
+	`)
+
+	idx := schemaindex.New(doc)
+	if got := idx.LookupQueryRoot(); got == nil || got.Name() != "SecondQuery" {
+		t.Fatalf("LookupQueryRoot() = %v; want SecondQuery", entryName(got))
+	}
+	if got := idx.LookupMutationRoot(); got == nil || got.Name() != "SecondMutation" {
+		t.Fatalf("LookupMutationRoot() = %v; want SecondMutation", entryName(got))
+	}
+	if got := idx.LookupSubscriptionRoot(); got == nil || got.Name() != "SecondSubscription" {
+		t.Fatalf("LookupSubscriptionRoot() = %v; want SecondSubscription", entryName(got))
+	}
+}
+
 func TestNewIgnoresNonTypeDefinitions(t *testing.T) {
 	doc, err := parser.Parse(`
 		schema { query: Root }
@@ -757,6 +899,13 @@ func requireObjectTypeExtension(t *testing.T, def ast.Definition) *ast.ObjectTyp
 		t.Fatalf("extension = %T; want *ast.ObjectTypeExtension", def)
 	}
 	return objectExt
+}
+
+func entryName(entry *schemaindex.TypeEntry) string {
+	if entry == nil {
+		return "<nil>"
+	}
+	return entry.Name()
 }
 
 func assertFieldNames(t *testing.T, fields ast.FieldDefinitionList, names ...string) {


### PR DESCRIPTION
## Summary
- add schema index lookup helpers for query, mutation, and subscription root operation types
- collect schema definition and schema extension operation roots in source order
- preserve the standard Query fallback only when no explicit query root is declared
- document the new root lookup helpers in the README

## Verification
- gofmt -l .
- go test ./...
- go vet ./...