### PR TITLE
Replace ad hoc comment handling with a typed CommentedNode interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ LSP can depend on AST types without dragging in the parser.
 
 ### Package responsibilities
 
-- `ast/` - `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; concrete pointer-receiver structs for every spec production; `Source`, `Position`, `Loc` with a lazy line-start index; `BlockStringValue`, `TypeString`, `NamedTypeName`, and `DirectiveStringArg` helpers; `Walk`/`Inspect`; `SyntaxError` with the graphql-js-style snippet renderer.
-- `lexer/` - synchronous, single-token-lookahead, hand-written tokenizer. `Token` carries byte offsets plus a `Value` that is a sub-slice of source for `NAME`/`INT`/`FLOAT`. `STRING` tokens own their decoded value. `Lexer.PreserveComments` is the internal switch the parser flips for `WithComments`.
+- `ast/` - `Node`, `Definition`, `Selection`, `Value`, `Type` interfaces; the `CommentedNode` interface (`CommentSlot() **CommentGroup`) implemented by every struct that carries a `Comments` field; concrete pointer-receiver structs for every spec production; `Source`, `Position`, `Loc` with a lazy line-start index; `BlockStringValue`, `TypeString`, `NamedTypeName`, and `DirectiveStringArg` helpers; `Walk`/`Inspect`; `SyntaxError` with the graphql-js-style snippet renderer.
+- `lexer/` - synchronous, single-token-lookahead, hand-written tokenizer. `Token` carries byte offsets plus a `Value` that is a sub-slice of source for `NAME`/`INT`/`FLOAT`. `STRING` tokens own their decoded value. Comment emission is sealed at construction via the `lexer.WithComments()` option to `lexer.New`; the parser passes it through when run with `WithComments`.
 - `parser/` - recursive descent. Public API is `Parse`, `ParseSource`, `ParseSchema`, `ParseSchemaSource`, `ParseValue`, `ParseConstValue`, `ParseType`, plus `WithRecovery()` and `WithComments()`. Everything else is unexported.
 - `schemaindex/` - small public SDL index over a parsed `*ast.Document`. `New` records the six named type definitions and six matching extension forms by name, keeps base definitions and extensions separate in source order, ignores non-type definitions, and does not validate schema semantics. Object, interface, input, enum, union, and scalar helper accessors expose base members followed by matching extension members without deduplicating or merging raw definitions. `LookupQueryRoot`/`LookupMutationRoot`/`LookupSubscriptionRoot` resolve `schema { ... }` and `extend schema` operation roots (last declaration in source order wins) through indexed type entries, falling back to SDL default root type names (`Query`, `Mutation`, `Subscription`) only when no explicit root is declared for that operation.
 
@@ -70,16 +70,29 @@ before `parseDefinition` is called, otherwise the first inner
 pattern:
 
 ```go
-defLeading := p.pendingLeading
-p.pendingLeading = nil
+leading := p.takeLeading()       // capture + clear the buffer at entry
 def, err := p.parseDefinition()
 ...
-attachLeadingComments(def, defLeading)
+p.bindLeading(def, leading)      // attach after the node is built
 ```
 
-`commentGroupOf(node)` is a type-switch returning `**ast.CommentGroup` for
-nodes that have a `Comments` field. Extend this when adding new node types that
-should carry trivia.
+`takeLeading` returns and clears `pendingLeading` so children start with an
+empty buffer (preserving capture-at-entry attribution); it runs unconditionally
+even when preservation is off. `bindLeading` attaches the captured comments
+through the `ast.CommentedNode` interface — a no-op when preservation is off,
+the slice is empty, or the node is nil.
+
+Every node with a `Comments *ast.CommentGroup` field implements
+`ast.CommentedNode` via a one-line `CommentSlot() **ast.CommentGroup` method, so
+there is no type switch to keep in sync. `bindLeading` is intentionally
+permissive: the assertion succeeds for any commented node, so binding *scope* is
+controlled by **where** `bindLeading` is called (currently only top-level
+definitions plus field, input-value, and enum-value definitions), not by the
+helper rejecting node types. Binding a new node type is a one-line `bindLeading`
+call at its production, not a switch case — but doing so is a behavior change
+that needs its own tests. The `ast/comment_test.go` registry + parity meta-test
+fails to compile (or fails at runtime) if a `Comments`-bearing struct is missing
+the method or the registry.
 
 ### Type-system parser dispatch
 

--- a/ast/comment.go
+++ b/ast/comment.go
@@ -17,3 +17,15 @@ type CommentGroup struct {
 	Leading  []*Comment
 	Trailing []*Comment
 }
+
+// CommentedNode is implemented by every AST node that carries a CommentGroup.
+// CommentSlot returns a pointer to the node's own Comments field, letting a
+// binder attach trivia without a type switch. The interface is the single
+// source of truth for "which nodes can hold comments"; the registry and parity
+// test in comment_test.go pin its implementors to the structs that actually
+// declare a Comments field. Implementing CommentedNode does not, by itself,
+// cause comments to be attached — only the parser's bind call sites do that.
+type CommentedNode interface {
+	Node
+	CommentSlot() **CommentGroup
+}

--- a/ast/comment_test.go
+++ b/ast/comment_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	gast "github.com/brian-bell/graphql-parser/ast"
@@ -89,8 +90,7 @@ func structsWithCommentsField(t *testing.T) map[string]bool {
 	found := map[string]bool{}
 	fset := token.NewFileSet()
 	for _, path := range matches {
-		if filepath.Base(path) != "" && len(path) >= len("_test.go") &&
-			path[len(path)-len("_test.go"):] == "_test.go" {
+		if strings.HasSuffix(path, "_test.go") {
 			continue
 		}
 		file, err := goparser.ParseFile(fset, path, nil, 0)

--- a/ast/comment_test.go
+++ b/ast/comment_test.go
@@ -1,0 +1,195 @@
+package ast_test
+
+import (
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"testing"
+
+	gast "github.com/brian-bell/graphql-parser/ast"
+)
+
+// commentedNodes registers every struct that carries a Comments *CommentGroup
+// field. The slice's element type, gast.CommentedNode, is the compile-time
+// proof that each listed type implements the interface: if a struct lacks the
+// CommentSlot method, its line here fails to compile. The parity test below
+// proves this list is exhaustive against the source.
+var commentedNodes = []gast.CommentedNode{
+	(*gast.Document)(nil),
+	(*gast.OperationDefinition)(nil),
+	(*gast.FragmentDefinition)(nil),
+	(*gast.VariableDefinition)(nil),
+	(*gast.SelectionSet)(nil),
+	(*gast.Field)(nil),
+	(*gast.FragmentSpread)(nil),
+	(*gast.InlineFragment)(nil),
+	(*gast.Argument)(nil),
+	(*gast.Directive)(nil),
+	(*gast.SchemaDefinition)(nil),
+	(*gast.SchemaExtension)(nil),
+	(*gast.OperationTypeDefinition)(nil),
+	(*gast.ScalarTypeDefinition)(nil),
+	(*gast.ScalarTypeExtension)(nil),
+	(*gast.ObjectTypeDefinition)(nil),
+	(*gast.ObjectTypeExtension)(nil),
+	(*gast.InterfaceTypeDefinition)(nil),
+	(*gast.InterfaceTypeExtension)(nil),
+	(*gast.UnionTypeDefinition)(nil),
+	(*gast.UnionTypeExtension)(nil),
+	(*gast.EnumTypeDefinition)(nil),
+	(*gast.EnumTypeExtension)(nil),
+	(*gast.InputObjectTypeDefinition)(nil),
+	(*gast.InputObjectTypeExtension)(nil),
+	(*gast.FieldDefinition)(nil),
+	(*gast.InputValueDefinition)(nil),
+	(*gast.EnumValueDefinition)(nil),
+	(*gast.DirectiveDefinition)(nil),
+	(*gast.IntValue)(nil),
+	(*gast.FloatValue)(nil),
+	(*gast.StringValue)(nil),
+	(*gast.BooleanValue)(nil),
+	(*gast.NullValue)(nil),
+	(*gast.EnumValue)(nil),
+	(*gast.ListValue)(nil),
+	(*gast.ObjectValue)(nil),
+	(*gast.ObjectField)(nil),
+	(*gast.Variable)(nil),
+}
+
+// commentedNodeCount pins the expected number of Comments-bearing structs. Both
+// the source-derived "expected" set and the registry "actual" set must hit this
+// count before the set comparison runs, so the test fails loudly rather than
+// degrading into two empty sets that compare equal if the glob under-collects.
+const commentedNodeCount = 39
+
+// astDir resolves the directory holding the production ast sources relative to
+// this test file, independent of the process working directory.
+func astDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(thisFile)
+}
+
+// structsWithCommentsField parses the non-test ast sources and returns the set
+// of struct type names that declare a Comments *CommentGroup field.
+func structsWithCommentsField(t *testing.T) map[string]bool {
+	t.Helper()
+	dir := astDir(t)
+	matches, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	found := map[string]bool{}
+	fset := token.NewFileSet()
+	for _, path := range matches {
+		if filepath.Base(path) != "" && len(path) >= len("_test.go") &&
+			path[len(path)-len("_test.go"):] == "_test.go" {
+			continue
+		}
+		file, err := goparser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+			for _, field := range st.Fields.List {
+				if !isCommentGroupPtr(field.Type) {
+					continue
+				}
+				for _, name := range field.Names {
+					if name.Name == "Comments" {
+						found[ts.Name.Name] = true
+					}
+				}
+			}
+			return true
+		})
+	}
+	return found
+}
+
+// isCommentGroupPtr reports whether expr is *CommentGroup.
+func isCommentGroupPtr(expr ast.Expr) bool {
+	star, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := star.X.(*ast.Ident)
+	return ok && ident.Name == "CommentGroup"
+}
+
+func TestCommentedNode_RegistryExhaustive(t *testing.T) {
+	expected := structsWithCommentsField(t)
+
+	actual := map[string]bool{}
+	for _, n := range commentedNodes {
+		actual[reflect.TypeOf(n).Elem().Name()] = true
+	}
+
+	if len(expected) != commentedNodeCount {
+		t.Fatalf("source declares %d Comments-bearing structs; want %d (glob under/over-collected: %s)",
+			len(expected), commentedNodeCount, sortedKeys(expected))
+	}
+	if len(commentedNodes) != commentedNodeCount {
+		t.Fatalf("commentedNodes registry has %d entries; want %d", len(commentedNodes), commentedNodeCount)
+	}
+
+	for name := range expected {
+		if !actual[name] {
+			t.Errorf("%s has a Comments field but is missing from the commentedNodes registry", name)
+		}
+	}
+	for name := range actual {
+		if !expected[name] {
+			t.Errorf("%s is registered in commentedNodes but has no Comments field in source", name)
+		}
+	}
+}
+
+func TestCommentedNode_SlotIdentity(t *testing.T) {
+	for _, n := range commentedNodes {
+		typ := reflect.TypeOf(n).Elem()
+		fresh := reflect.New(typ) // *T, addressable
+		cn, ok := fresh.Interface().(gast.CommentedNode)
+		if !ok {
+			t.Fatalf("%s does not implement CommentedNode", typ.Name())
+		}
+		slot := cn.CommentSlot()
+		group := &gast.CommentGroup{}
+		*slot = group
+
+		field := fresh.Elem().FieldByName("Comments")
+		if !field.IsValid() {
+			t.Fatalf("%s has no Comments field", typ.Name())
+		}
+		if field.IsNil() {
+			t.Errorf("%s.CommentSlot did not write through to the Comments field", typ.Name())
+		}
+		if field.Interface().(*gast.CommentGroup) != group {
+			t.Errorf("%s.CommentSlot returned a pointer to a different field than Comments", typ.Name())
+		}
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/ast/document.go
+++ b/ast/document.go
@@ -14,6 +14,9 @@ type Document struct {
 // GetLoc returns the document's location.
 func (d *Document) GetLoc() *Loc { return d.Loc }
 
+// CommentSlot returns a pointer to the document's Comments field.
+func (d *Document) CommentSlot() **CommentGroup { return &d.Comments }
+
 // DefinitionList is a slice of Definition with helper methods.
 type DefinitionList []Definition
 

--- a/ast/executable.go
+++ b/ast/executable.go
@@ -25,8 +25,9 @@ type OperationDefinition struct {
 	Comments            *CommentGroup
 }
 
-func (d *OperationDefinition) GetLoc() *Loc { return d.Loc }
-func (*OperationDefinition) isDefinition()  {}
+func (d *OperationDefinition) GetLoc() *Loc                { return d.Loc }
+func (*OperationDefinition) isDefinition()                 {}
+func (d *OperationDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // FragmentDefinition is a named fragment: "fragment Name on Type { ... }".
 type FragmentDefinition struct {
@@ -38,8 +39,9 @@ type FragmentDefinition struct {
 	Comments      *CommentGroup
 }
 
-func (d *FragmentDefinition) GetLoc() *Loc { return d.Loc }
-func (*FragmentDefinition) isDefinition()  {}
+func (d *FragmentDefinition) GetLoc() *Loc                { return d.Loc }
+func (*FragmentDefinition) isDefinition()                 {}
+func (d *FragmentDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // VariableDefinition declares an operation variable: "$name: Type = default
 // @directive...".
@@ -52,7 +54,8 @@ type VariableDefinition struct {
 	Comments     *CommentGroup
 }
 
-func (v *VariableDefinition) GetLoc() *Loc { return v.Loc }
+func (v *VariableDefinition) GetLoc() *Loc                { return v.Loc }
+func (v *VariableDefinition) CommentSlot() **CommentGroup { return &v.Comments }
 
 // SelectionSet is a "{ ... }" block of one or more Selections.
 type SelectionSet struct {
@@ -62,7 +65,8 @@ type SelectionSet struct {
 }
 
 // GetLoc returns the location covering the selection set including its braces.
-func (s *SelectionSet) GetLoc() *Loc { return s.Loc }
+func (s *SelectionSet) GetLoc() *Loc                { return s.Loc }
+func (s *SelectionSet) CommentSlot() **CommentGroup { return &s.Comments }
 
 // Field is a leaf or non-leaf selection: "[alias:] name(args)? @dir...?
 // SelectionSet?".
@@ -76,8 +80,9 @@ type Field struct {
 	Comments     *CommentGroup
 }
 
-func (f *Field) GetLoc() *Loc { return f.Loc }
-func (*Field) isSelection()   {}
+func (f *Field) GetLoc() *Loc                { return f.Loc }
+func (*Field) isSelection()                  {}
+func (f *Field) CommentSlot() **CommentGroup { return &f.Comments }
 
 // FragmentSpread is "...FragmentName Directives?". The name must not be "on";
 // the parser disambiguates against InlineFragment.
@@ -88,8 +93,9 @@ type FragmentSpread struct {
 	Comments   *CommentGroup
 }
 
-func (s *FragmentSpread) GetLoc() *Loc { return s.Loc }
-func (*FragmentSpread) isSelection()   {}
+func (s *FragmentSpread) GetLoc() *Loc                { return s.Loc }
+func (*FragmentSpread) isSelection()                  {}
+func (s *FragmentSpread) CommentSlot() **CommentGroup { return &s.Comments }
 
 // InlineFragment is "... TypeCondition? Directives? SelectionSet". The
 // type condition is optional; when absent, the fragment inherits the
@@ -102,8 +108,9 @@ type InlineFragment struct {
 	Comments      *CommentGroup
 }
 
-func (f *InlineFragment) GetLoc() *Loc { return f.Loc }
-func (*InlineFragment) isSelection()   {}
+func (f *InlineFragment) GetLoc() *Loc                { return f.Loc }
+func (*InlineFragment) isSelection()                  {}
+func (f *InlineFragment) CommentSlot() **CommentGroup { return &f.Comments }
 
 // Argument is one "name: value" entry in a function-style argument list.
 type Argument struct {
@@ -113,7 +120,8 @@ type Argument struct {
 	Comments *CommentGroup
 }
 
-func (a *Argument) GetLoc() *Loc { return a.Loc }
+func (a *Argument) GetLoc() *Loc                { return a.Loc }
+func (a *Argument) CommentSlot() **CommentGroup { return &a.Comments }
 
 // Directive is "@name(args)?". Arguments must be const values when the
 // directive appears on a type-system definition; the parser enforces this
@@ -125,4 +133,5 @@ type Directive struct {
 	Comments  *CommentGroup
 }
 
-func (d *Directive) GetLoc() *Loc { return d.Loc }
+func (d *Directive) GetLoc() *Loc                { return d.Loc }
+func (d *Directive) CommentSlot() **CommentGroup { return &d.Comments }

--- a/ast/schema.go
+++ b/ast/schema.go
@@ -9,8 +9,9 @@ type SchemaDefinition struct {
 	Comments       *CommentGroup
 }
 
-func (d *SchemaDefinition) GetLoc() *Loc { return d.Loc }
-func (*SchemaDefinition) isDefinition()  {}
+func (d *SchemaDefinition) GetLoc() *Loc                { return d.Loc }
+func (*SchemaDefinition) isDefinition()                 {}
+func (d *SchemaDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // SchemaExtension extends a schema with additional directives and/or root
 // operation types.
@@ -21,8 +22,9 @@ type SchemaExtension struct {
 	Comments       *CommentGroup
 }
 
-func (d *SchemaExtension) GetLoc() *Loc { return d.Loc }
-func (*SchemaExtension) isDefinition()  {}
+func (d *SchemaExtension) GetLoc() *Loc                { return d.Loc }
+func (*SchemaExtension) isDefinition()                 {}
+func (d *SchemaExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
 // OperationTypeDefinition is one "query: Query" entry inside a SchemaDefinition.
 type OperationTypeDefinition struct {
@@ -32,7 +34,8 @@ type OperationTypeDefinition struct {
 	Comments  *CommentGroup
 }
 
-func (d *OperationTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (d *OperationTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *OperationTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // ScalarTypeDefinition declares a custom scalar type.
 type ScalarTypeDefinition struct {
@@ -43,8 +46,9 @@ type ScalarTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *ScalarTypeDefinition) GetLoc() *Loc { return d.Loc }
-func (*ScalarTypeDefinition) isDefinition()  {}
+func (d *ScalarTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (*ScalarTypeDefinition) isDefinition()                 {}
+func (d *ScalarTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // ScalarTypeExtension adds directives to an existing scalar type.
 type ScalarTypeExtension struct {
@@ -54,8 +58,9 @@ type ScalarTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *ScalarTypeExtension) GetLoc() *Loc { return d.Loc }
-func (*ScalarTypeExtension) isDefinition()  {}
+func (d *ScalarTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (*ScalarTypeExtension) isDefinition()                 {}
+func (d *ScalarTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
 // ObjectTypeDefinition declares a GraphQL object type.
 type ObjectTypeDefinition struct {
@@ -68,8 +73,9 @@ type ObjectTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *ObjectTypeDefinition) GetLoc() *Loc { return d.Loc }
-func (*ObjectTypeDefinition) isDefinition()  {}
+func (d *ObjectTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (*ObjectTypeDefinition) isDefinition()                 {}
+func (d *ObjectTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // ObjectTypeExtension extends an existing object type.
 type ObjectTypeExtension struct {
@@ -81,8 +87,9 @@ type ObjectTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *ObjectTypeExtension) GetLoc() *Loc { return d.Loc }
-func (*ObjectTypeExtension) isDefinition()  {}
+func (d *ObjectTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (*ObjectTypeExtension) isDefinition()                 {}
+func (d *ObjectTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
 // InterfaceTypeDefinition declares an interface type.
 type InterfaceTypeDefinition struct {
@@ -95,8 +102,9 @@ type InterfaceTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *InterfaceTypeDefinition) GetLoc() *Loc { return d.Loc }
-func (*InterfaceTypeDefinition) isDefinition()  {}
+func (d *InterfaceTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (*InterfaceTypeDefinition) isDefinition()                 {}
+func (d *InterfaceTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // InterfaceTypeExtension extends an interface type.
 type InterfaceTypeExtension struct {
@@ -108,8 +116,9 @@ type InterfaceTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *InterfaceTypeExtension) GetLoc() *Loc { return d.Loc }
-func (*InterfaceTypeExtension) isDefinition()  {}
+func (d *InterfaceTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (*InterfaceTypeExtension) isDefinition()                 {}
+func (d *InterfaceTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
 // UnionTypeDefinition declares a union type: "union U = A | B | C".
 type UnionTypeDefinition struct {
@@ -121,8 +130,9 @@ type UnionTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *UnionTypeDefinition) GetLoc() *Loc { return d.Loc }
-func (*UnionTypeDefinition) isDefinition()  {}
+func (d *UnionTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (*UnionTypeDefinition) isDefinition()                 {}
+func (d *UnionTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // UnionTypeExtension extends a union type.
 type UnionTypeExtension struct {
@@ -133,8 +143,9 @@ type UnionTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *UnionTypeExtension) GetLoc() *Loc { return d.Loc }
-func (*UnionTypeExtension) isDefinition()  {}
+func (d *UnionTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (*UnionTypeExtension) isDefinition()                 {}
+func (d *UnionTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
 // EnumTypeDefinition declares an enum type.
 type EnumTypeDefinition struct {
@@ -146,8 +157,9 @@ type EnumTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *EnumTypeDefinition) GetLoc() *Loc { return d.Loc }
-func (*EnumTypeDefinition) isDefinition()  {}
+func (d *EnumTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (*EnumTypeDefinition) isDefinition()                 {}
+func (d *EnumTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // EnumTypeExtension extends an enum type.
 type EnumTypeExtension struct {
@@ -158,8 +170,9 @@ type EnumTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *EnumTypeExtension) GetLoc() *Loc { return d.Loc }
-func (*EnumTypeExtension) isDefinition()  {}
+func (d *EnumTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (*EnumTypeExtension) isDefinition()                 {}
+func (d *EnumTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
 // InputObjectTypeDefinition declares an input object type.
 type InputObjectTypeDefinition struct {
@@ -171,8 +184,9 @@ type InputObjectTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *InputObjectTypeDefinition) GetLoc() *Loc { return d.Loc }
-func (*InputObjectTypeDefinition) isDefinition()  {}
+func (d *InputObjectTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (*InputObjectTypeDefinition) isDefinition()                 {}
+func (d *InputObjectTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // InputObjectTypeExtension extends an input object type.
 type InputObjectTypeExtension struct {
@@ -183,8 +197,9 @@ type InputObjectTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *InputObjectTypeExtension) GetLoc() *Loc { return d.Loc }
-func (*InputObjectTypeExtension) isDefinition()  {}
+func (d *InputObjectTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (*InputObjectTypeExtension) isDefinition()                 {}
+func (d *InputObjectTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
 // FieldDefinition is one entry inside an Object or Interface type, e.g.
 // "name(args): Type @directive...".
@@ -198,7 +213,8 @@ type FieldDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *FieldDefinition) GetLoc() *Loc { return d.Loc }
+func (d *FieldDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *FieldDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // InputValueDefinition is used for both argument definitions (on
 // FieldDefinition / DirectiveDefinition) and input-object fields. It
@@ -213,7 +229,8 @@ type InputValueDefinition struct {
 	Comments     *CommentGroup
 }
 
-func (d *InputValueDefinition) GetLoc() *Loc { return d.Loc }
+func (d *InputValueDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *InputValueDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // EnumValueDefinition is one entry inside an EnumTypeDefinition. The Name
 // must not be true, false, or null per spec.
@@ -225,7 +242,8 @@ type EnumValueDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *EnumValueDefinition) GetLoc() *Loc { return d.Loc }
+func (d *EnumValueDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *EnumValueDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // DirectiveDefinition declares a directive: "directive @name(args) on LOCATIONS".
 // Repeatable is true if the definition included the "repeatable" keyword.
@@ -239,8 +257,9 @@ type DirectiveDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *DirectiveDefinition) GetLoc() *Loc { return d.Loc }
-func (*DirectiveDefinition) isDefinition()  {}
+func (d *DirectiveDefinition) GetLoc() *Loc                { return d.Loc }
+func (*DirectiveDefinition) isDefinition()                 {}
+func (d *DirectiveDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // FieldDefinitionList is a slice of *FieldDefinition with helper methods.
 type FieldDefinitionList []*FieldDefinition

--- a/ast/value.go
+++ b/ast/value.go
@@ -9,8 +9,9 @@ type IntValue struct {
 	Comments *CommentGroup
 }
 
-func (v *IntValue) GetLoc() *Loc { return v.Loc }
-func (*IntValue) isValue()       {}
+func (v *IntValue) GetLoc() *Loc                { return v.Loc }
+func (*IntValue) isValue()                      {}
+func (v *IntValue) CommentSlot() **CommentGroup { return &v.Comments }
 
 // FloatValue is a floating-point literal. Value is the raw lexeme.
 type FloatValue struct {
@@ -19,8 +20,9 @@ type FloatValue struct {
 	Comments *CommentGroup
 }
 
-func (v *FloatValue) GetLoc() *Loc { return v.Loc }
-func (*FloatValue) isValue()       {}
+func (v *FloatValue) GetLoc() *Loc                { return v.Loc }
+func (*FloatValue) isValue()                      {}
+func (v *FloatValue) CommentSlot() **CommentGroup { return &v.Comments }
 
 // StringValue is a string literal. Value is the post-decode value: escape
 // sequences are processed for "..." and the BlockStringValue dedent is
@@ -33,8 +35,9 @@ type StringValue struct {
 	Comments *CommentGroup
 }
 
-func (v *StringValue) GetLoc() *Loc { return v.Loc }
-func (*StringValue) isValue()       {}
+func (v *StringValue) GetLoc() *Loc                { return v.Loc }
+func (*StringValue) isValue()                      {}
+func (v *StringValue) CommentSlot() **CommentGroup { return &v.Comments }
 
 // BooleanValue is one of the keywords true or false.
 type BooleanValue struct {
@@ -43,8 +46,9 @@ type BooleanValue struct {
 	Comments *CommentGroup
 }
 
-func (v *BooleanValue) GetLoc() *Loc { return v.Loc }
-func (*BooleanValue) isValue()       {}
+func (v *BooleanValue) GetLoc() *Loc                { return v.Loc }
+func (*BooleanValue) isValue()                      {}
+func (v *BooleanValue) CommentSlot() **CommentGroup { return &v.Comments }
 
 // NullValue is the null keyword.
 type NullValue struct {
@@ -52,8 +56,9 @@ type NullValue struct {
 	Comments *CommentGroup
 }
 
-func (v *NullValue) GetLoc() *Loc { return v.Loc }
-func (*NullValue) isValue()       {}
+func (v *NullValue) GetLoc() *Loc                { return v.Loc }
+func (*NullValue) isValue()                      {}
+func (v *NullValue) CommentSlot() **CommentGroup { return &v.Comments }
 
 // EnumValue is an enum literal — a Name that is not true, false, or null.
 type EnumValue struct {
@@ -62,8 +67,9 @@ type EnumValue struct {
 	Comments *CommentGroup
 }
 
-func (v *EnumValue) GetLoc() *Loc { return v.Loc }
-func (*EnumValue) isValue()       {}
+func (v *EnumValue) GetLoc() *Loc                { return v.Loc }
+func (*EnumValue) isValue()                      {}
+func (v *EnumValue) CommentSlot() **CommentGroup { return &v.Comments }
 
 // ListValue is a [...] list literal.
 type ListValue struct {
@@ -72,8 +78,9 @@ type ListValue struct {
 	Comments *CommentGroup
 }
 
-func (v *ListValue) GetLoc() *Loc { return v.Loc }
-func (*ListValue) isValue()       {}
+func (v *ListValue) GetLoc() *Loc                { return v.Loc }
+func (*ListValue) isValue()                      {}
+func (v *ListValue) CommentSlot() **CommentGroup { return &v.Comments }
 
 // ObjectValue is a {field: value, ...} object literal.
 type ObjectValue struct {
@@ -82,8 +89,9 @@ type ObjectValue struct {
 	Comments *CommentGroup
 }
 
-func (v *ObjectValue) GetLoc() *Loc { return v.Loc }
-func (*ObjectValue) isValue()       {}
+func (v *ObjectValue) GetLoc() *Loc                { return v.Loc }
+func (*ObjectValue) isValue()                      {}
+func (v *ObjectValue) CommentSlot() **CommentGroup { return &v.Comments }
 
 // ObjectField is one Name: Value entry inside an ObjectValue.
 type ObjectField struct {
@@ -93,7 +101,8 @@ type ObjectField struct {
 	Comments *CommentGroup
 }
 
-func (f *ObjectField) GetLoc() *Loc { return f.Loc }
+func (f *ObjectField) GetLoc() *Loc                { return f.Loc }
+func (f *ObjectField) CommentSlot() **CommentGroup { return &f.Comments }
 
 // Variable is a $name reference. It implements Value but the parser refuses
 // to produce one inside a const-value context (default values, directive
@@ -104,5 +113,6 @@ type Variable struct {
 	Comments *CommentGroup
 }
 
-func (v *Variable) GetLoc() *Loc { return v.Loc }
-func (*Variable) isValue()       {}
+func (v *Variable) GetLoc() *Loc                { return v.Loc }
+func (*Variable) isValue()                      {}
+func (v *Variable) CommentSlot() **CommentGroup { return &v.Comments }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -15,22 +15,41 @@ type Lexer struct {
 	body   string // == source.Body, cached for the hot loop
 	pos    int    // current byte offset into body
 
-	// PreserveComments controls whether COMMENT tokens reach the caller.
+	// preserveComments controls whether COMMENT tokens reach the caller.
 	// When false (the default), the lexer skips comments silently as required
 	// by the GraphQL grammar (they are "ignored tokens"). When true, each
 	// comment is emitted as a COMMENT token whose Value is the text after
-	// '#' up to (but not including) the line terminator.
-	PreserveComments bool
+	// '#' up to (but not including) the line terminator. Set it through the
+	// WithComments constructor option; it is sealed at construction.
+	preserveComments bool
 
 	peeked    bool
 	peekedTok Token
 	peekedErr error
 }
 
+// Option configures a Lexer at construction time.
+type Option func(*Lexer)
+
+// WithComments makes the lexer emit COMMENT tokens instead of silently
+// skipping them. Without this option the lexer treats comments as ignored
+// tokens per the GraphQL grammar. The parser flips this on for its own lexer
+// when run with parser.WithComments.
+func WithComments() Option {
+	return func(l *Lexer) { l.preserveComments = true }
+}
+
 // New constructs a Lexer for the given source. The source must outlive the
-// Lexer; tokens hold byte offsets into Source.Body.
-func New(src *ast.Source) *Lexer {
-	return &Lexer{source: src, body: src.Body}
+// Lexer; tokens hold byte offsets into Source.Body. Pass WithComments to make
+// the lexer emit COMMENT tokens; by default comments are skipped.
+func New(src *ast.Source, opts ...Option) *Lexer {
+	l := &Lexer{source: src, body: src.Body}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(l)
+		}
+	}
+	return l
 }
 
 // Source returns the underlying source.
@@ -148,7 +167,7 @@ func (l *Lexer) singleByte(k Kind) Token {
 }
 
 // skipIgnored advances past ignored tokens: BOM, whitespace, line terminators,
-// commas, and (when PreserveComments is false) comments. Comments are always
+// commas, and (when comment preservation is off) comments. Comments are always
 // lexed for their byte range; this method just skips them when retention is off.
 func (l *Lexer) skipIgnored() {
 	for l.pos < len(l.body) {
@@ -164,7 +183,7 @@ func (l *Lexer) skipIgnored() {
 			}
 			return
 		case '#':
-			if l.PreserveComments {
+			if l.preserveComments {
 				return
 			}
 			// Skip to end of line; do not consume the terminator (the loop
@@ -180,10 +199,10 @@ func (l *Lexer) skipIgnored() {
 
 // lexComment reads a # comment, starting at the '#'. The returned token's
 // Value is the comment text (after '#', before the line terminator).
-// It returns ok=false if PreserveComments is false; in that case the caller
-// should resume looking for the next non-ignored token.
+// It returns ok=false when comment preservation is off; in that case the
+// caller should resume looking for the next non-ignored token.
 func (l *Lexer) lexComment() (Token, bool, error) {
-	if !l.PreserveComments {
+	if !l.preserveComments {
 		// skipIgnored should have absorbed it; defensive.
 		for l.pos < len(l.body) && l.body[l.pos] != '\n' && l.body[l.pos] != '\r' {
 			l.pos++

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -239,9 +239,24 @@ func TestLexer_CommentSkippedByDefault(t *testing.T) {
 	}
 }
 
+func TestLexer_DefaultSkipsComments(t *testing.T) {
+	l := lexer.New(&ast.Source{Body: "# hello\nfoo", Name: "test.graphql"})
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.NAME || tok.Value != "foo" {
+		t.Errorf("default New should skip comments; got %v %q", tok.Kind, tok.Value)
+	}
+}
+
+func TestLexer_WithCommentsOption(t *testing.T) {
+	l := lexer.New(&ast.Source{Body: "# hello\nfoo", Name: "test.graphql"}, lexer.WithComments())
+	tok := mustNext(t, l)
+	if tok.Kind != lexer.COMMENT || tok.Value != " hello" {
+		t.Errorf("WithComments should emit COMMENT; got %v %q", tok.Kind, tok.Value)
+	}
+}
+
 func TestLexer_CommentRetained(t *testing.T) {
-	l := lex(t, "# hello\nfoo")
-	l.PreserveComments = true
+	l := lexer.New(&ast.Source{Body: "# hello\nfoo", Name: "test.graphql"}, lexer.WithComments())
 	tok := mustNext(t, l)
 	if tok.Kind != lexer.COMMENT {
 		t.Fatalf("got %v; want COMMENT", tok.Kind)

--- a/parser/bindleading_test.go
+++ b/parser/bindleading_test.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/brian-bell/graphql-parser/ast"
+)
+
+// TestBindLeading_PermissiveOnLatentNodes documents that bindLeading is
+// intentionally permissive: now that all 39 Comments-bearing nodes implement
+// ast.CommentedNode, the interface assertion succeeds even for the latent
+// value nodes the parser never binds today. Behavior is preserved because the
+// four call sites only pass nodes that were always bound — scope is controlled
+// by *where* bindLeading is called, not by the helper rejecting node types.
+func TestBindLeading_PermissiveOnLatentNodes(t *testing.T) {
+	p := &parser{cfg: &config{preserveComments: true}}
+	iv := &ast.IntValue{Value: "1"}
+	leading := []*ast.Comment{{Text: " a comment"}}
+
+	p.bindLeading(iv, leading)
+
+	if iv.Comments == nil || len(iv.Comments.Leading) != 1 || iv.Comments.Leading[0].Text != " a comment" {
+		t.Errorf("bindLeading should populate even a latent node's Comments; got %+v", iv.Comments)
+	}
+}
+
+// TestBindLeading_NoOpWhenPreservationOff pins that bindLeading does nothing
+// when comment preservation is off, even though takeLeading still runs.
+func TestBindLeading_NoOpWhenPreservationOff(t *testing.T) {
+	p := &parser{cfg: &config{preserveComments: false}}
+	fd := &ast.FieldDefinition{Name: "x"}
+	p.bindLeading(fd, []*ast.Comment{{Text: " ignored"}})
+	if fd.Comments != nil {
+		t.Errorf("bindLeading should be a no-op when preservation is off; got %+v", fd.Comments)
+	}
+}

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -8,7 +8,7 @@ import (
 // drainComments consumes any pending COMMENT tokens at the current lexer
 // position into p.pendingLeading. Called from peek/advance whenever
 // preserveComments is on; a no-op otherwise (the lexer doesn't emit
-// COMMENT tokens unless PreserveComments is set).
+// COMMENT tokens unless built with lexer.WithComments).
 func (p *parser) drainComments() {
 	if !p.cfg.preserveComments {
 		return
@@ -33,69 +33,36 @@ func (p *parser) drainComments() {
 	}
 }
 
-// attachLeadingComments writes the given comment slice onto a node's
-// Comments.Leading field. No-op when leading is empty or the node has no
-// Comments field (e.g. a Type reference).
-func attachLeadingComments(n ast.Node, leading []*ast.Comment) {
-	if len(leading) == 0 || n == nil {
-		return
-	}
-	cg := commentGroupOf(n)
-	if cg == nil {
-		return
-	}
-	if *cg == nil {
-		*cg = &ast.CommentGroup{}
-	}
-	(*cg).Leading = append((*cg).Leading, leading...)
+// takeLeading returns and clears the pending leading-comment buffer. Call it at
+// the entry of a production whose node owns those comments, before parsing any
+// children (which would otherwise drain their own comments into the same
+// buffer and steal attribution). It runs unconditionally — do NOT add a
+// preserveComments guard here. The buffer must be cleared even when
+// preservation is off so timing matches the historical capture-at-entry code;
+// when off, drainComments never fills it, so the clear is a harmless no-op.
+func (p *parser) takeLeading() []*ast.Comment {
+	leading := p.pendingLeading
+	p.pendingLeading = nil
+	return leading
 }
 
-// commentGroupOf returns a pointer to the Comments field of n, or nil if n
-// has no such field.
-func commentGroupOf(n ast.Node) **ast.CommentGroup {
-	switch v := n.(type) {
-	case *ast.Document:
-		return &v.Comments
-	case *ast.OperationDefinition:
-		return &v.Comments
-	case *ast.FragmentDefinition:
-		return &v.Comments
-	case *ast.SchemaDefinition:
-		return &v.Comments
-	case *ast.SchemaExtension:
-		return &v.Comments
-	case *ast.ScalarTypeDefinition:
-		return &v.Comments
-	case *ast.ScalarTypeExtension:
-		return &v.Comments
-	case *ast.ObjectTypeDefinition:
-		return &v.Comments
-	case *ast.ObjectTypeExtension:
-		return &v.Comments
-	case *ast.InterfaceTypeDefinition:
-		return &v.Comments
-	case *ast.InterfaceTypeExtension:
-		return &v.Comments
-	case *ast.UnionTypeDefinition:
-		return &v.Comments
-	case *ast.UnionTypeExtension:
-		return &v.Comments
-	case *ast.EnumTypeDefinition:
-		return &v.Comments
-	case *ast.EnumTypeExtension:
-		return &v.Comments
-	case *ast.InputObjectTypeDefinition:
-		return &v.Comments
-	case *ast.InputObjectTypeExtension:
-		return &v.Comments
-	case *ast.DirectiveDefinition:
-		return &v.Comments
-	case *ast.FieldDefinition:
-		return &v.Comments
-	case *ast.InputValueDefinition:
-		return &v.Comments
-	case *ast.EnumValueDefinition:
-		return &v.Comments
+// bindLeading attaches captured leading comments to n through the
+// ast.CommentedNode interface. It is a no-op when preservation is off, the
+// slice is empty, or n is nil/does not carry comments. The assertion succeeds
+// for any node that has a Comments field, so binding scope is controlled by
+// where this is called, not by the helper rejecting node types: the parser
+// only calls it at the four sites that historically bound leading comments.
+func (p *parser) bindLeading(n ast.Node, leading []*ast.Comment) {
+	if !p.cfg.preserveComments || len(leading) == 0 || n == nil {
+		return
 	}
-	return nil
+	cn, ok := n.(ast.CommentedNode)
+	if !ok {
+		return
+	}
+	slot := cn.CommentSlot()
+	if *slot == nil {
+		*slot = &ast.CommentGroup{}
+	}
+	(*slot).Leading = append((*slot).Leading, leading...)
 }

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -143,6 +143,119 @@ type T {
 	}
 }
 
+func TestComments_DefinitionVsFirstFieldAttribution(t *testing.T) {
+	body := `
+# the type
+type T {
+	# the first field
+	id: ID!
+}`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	if def.Comments == nil || len(def.Comments.Leading) != 1 || def.Comments.Leading[0].Text != " the type" {
+		t.Fatalf("type leading comments wrong: %+v", def.Comments)
+	}
+	id := def.Fields.ForName("id")
+	if id.Comments == nil || len(id.Comments.Leading) != 1 || id.Comments.Leading[0].Text != " the first field" {
+		t.Fatalf("field leading comments wrong: %+v", id.Comments)
+	}
+	// The type's comment must not leak onto the field, nor the field's onto the
+	// type — pins the capture-at-entry timing.
+	for _, c := range def.Comments.Leading {
+		if c.Text == " the first field" {
+			t.Errorf("field comment leaked onto the type")
+		}
+	}
+	for _, c := range id.Comments.Leading {
+		if c.Text == " the type" {
+			t.Errorf("type comment leaked onto the field")
+		}
+	}
+}
+
+func TestComments_WithRecovery_NoBleedAcrossBadDefinition(t *testing.T) {
+	body := `
+# bad one
+type 123
+# good one
+type Good { x: Int }`
+	doc, _ := parser.Parse(body, parser.WithComments(), parser.WithRecovery())
+	if doc == nil {
+		t.Fatal("expected a document even with a malformed definition")
+	}
+	var good *ast.ObjectTypeDefinition
+	for _, d := range doc.Definitions {
+		if obj, ok := d.(*ast.ObjectTypeDefinition); ok && obj.Name == "Good" {
+			good = obj
+		}
+	}
+	if good == nil {
+		t.Fatal("surviving Good definition not found")
+	}
+	if good.Comments == nil || len(good.Comments.Leading) != 1 || good.Comments.Leading[0].Text != " good one" {
+		t.Errorf("surviving definition lost/leaked comments: %+v", good.Comments)
+	}
+}
+
+func TestComments_NestedInputValueAttribution(t *testing.T) {
+	body := `
+type T {
+	# the field itself
+	field(
+		# the arg
+		arg: Int
+	): Boolean
+}`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	f := def.Fields.ForName("field")
+	if f.Comments == nil || len(f.Comments.Leading) != 1 || f.Comments.Leading[0].Text != " the field itself" {
+		t.Fatalf("field comments wrong: %+v", f.Comments)
+	}
+	arg := f.Arguments.ForName("arg")
+	if arg.Comments == nil || len(arg.Comments.Leading) != 1 || arg.Comments.Leading[0].Text != " the arg" {
+		t.Fatalf("arg comments wrong: %+v", arg.Comments)
+	}
+	// The arg comment must attach to the InputValueDefinition, not the field.
+	for _, c := range f.Comments.Leading {
+		if c.Text == " the arg" {
+			t.Errorf("arg comment leaked onto the field")
+		}
+	}
+}
+
+func TestComments_LatentNodesStayNil(t *testing.T) {
+	body := `
+type T {
+	# the field
+	field(
+		# the arg
+		arg: Int = 42
+	): Boolean
+}`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	arg := def.Fields.ForName("field").Arguments.ForName("arg")
+	// The default value is an IntValue — a latent node the parser does not bind
+	// comments to. Pin that scope did not widen.
+	if iv, ok := arg.DefaultValue.(*ast.IntValue); ok {
+		if iv.Comments != nil {
+			t.Errorf("IntValue default unexpectedly carries comments: %+v", iv.Comments)
+		}
+	} else {
+		t.Fatalf("default value is %T; want *ast.IntValue", arg.DefaultValue)
+	}
+}
+
 func TestComments_NoComments_NoCommentGroup(t *testing.T) {
 	body := `type T { x: Int }`
 	doc, err := parser.Parse(body, parser.WithComments())

--- a/parser/document.go
+++ b/parser/document.go
@@ -30,8 +30,7 @@ func (p *parser) parseDocument() (*ast.Document, error) {
 		defStart := tok.Start
 		// Capture the leading-comment buffer for THIS definition before any
 		// inner parser (e.g. its first FieldDefinition) can take it.
-		defLeading := p.pendingLeading
-		p.pendingLeading = nil
+		defLeading := p.takeLeading()
 		def, err := p.parseDefinition()
 		if err != nil {
 			if !p.recordError(err) {
@@ -42,7 +41,7 @@ func (p *parser) parseDocument() (*ast.Document, error) {
 			defs = append(defs, &ast.BadDefinition{Err: se, Loc: p.loc(defStart)})
 			continue
 		}
-		attachLeadingComments(def, defLeading)
+		p.bindLeading(def, defLeading)
 		defs = append(defs, def)
 	}
 	if len(defs) == 0 {

--- a/parser/options.go
+++ b/parser/options.go
@@ -30,7 +30,7 @@ func WithRecovery() Option {
 //
 // Trailing comments and value/type-level comments are not yet attributed;
 // callers needing the full comment stream can read raw COMMENT tokens
-// directly from a [lexer.Lexer] with PreserveComments=true.
+// directly from a [lexer.Lexer] constructed with [lexer.WithComments].
 func WithComments() Option {
 	return func(c *config) { c.preserveComments = true }
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -25,10 +25,11 @@ type parser struct {
 
 func newParser(src *ast.Source, opts []Option) *parser {
 	cfg := newConfig(opts)
-	l := lexer.New(src)
+	var lopts []lexer.Option
 	if cfg.preserveComments {
-		l.PreserveComments = true
+		lopts = append(lopts, lexer.WithComments())
 	}
+	l := lexer.New(src, lopts...)
 	return &parser{source: src, lex: l, cfg: cfg}
 }
 

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -315,8 +315,7 @@ func (p *parser) parseFieldsDefinition() (ast.FieldDefinitionList, error) {
 }
 
 func (p *parser) parseFieldDefinition() (*ast.FieldDefinition, error) {
-	leading := p.pendingLeading
-	p.pendingLeading = nil
+	leading := p.takeLeading()
 	desc, descStart, err := p.parseOptionalDescription()
 	if err != nil {
 		return nil, err
@@ -352,9 +351,7 @@ func (p *parser) parseFieldDefinition() (*ast.FieldDefinition, error) {
 		Directives:  dirs,
 		Loc:         p.loc(start),
 	}
-	if len(leading) > 0 {
-		fd.Comments = &ast.CommentGroup{Leading: leading}
-	}
+	p.bindLeading(fd, leading)
 	return fd, nil
 }
 
@@ -394,8 +391,7 @@ func (p *parser) parseArgumentsDefinition() (ast.InputValueList, error) {
 }
 
 func (p *parser) parseInputValueDefinition() (*ast.InputValueDefinition, error) {
-	leading := p.pendingLeading
-	p.pendingLeading = nil
+	leading := p.takeLeading()
 	desc, descStart, err := p.parseOptionalDescription()
 	if err != nil {
 		return nil, err
@@ -437,9 +433,7 @@ func (p *parser) parseInputValueDefinition() (*ast.InputValueDefinition, error) 
 		Directives:   dirs,
 		Loc:          p.loc(start),
 	}
-	if len(leading) > 0 {
-		iv.Comments = &ast.CommentGroup{Leading: leading}
-	}
+	p.bindLeading(iv, leading)
 	return iv, nil
 }
 
@@ -558,8 +552,7 @@ func (p *parser) parseEnumValuesDefinition() (ast.EnumValueList, error) {
 }
 
 func (p *parser) parseEnumValueDefinition() (*ast.EnumValueDefinition, error) {
-	leading := p.pendingLeading
-	p.pendingLeading = nil
+	leading := p.takeLeading()
 	desc, descStart, err := p.parseOptionalDescription()
 	if err != nil {
 		return nil, err
@@ -586,9 +579,7 @@ func (p *parser) parseEnumValueDefinition() (*ast.EnumValueDefinition, error) {
 		Directives:  dirs,
 		Loc:         p.loc(start),
 	}
-	if len(leading) > 0 {
-		ev.Comments = &ast.CommentGroup{Leading: leading}
-	}
+	p.bindLeading(ev, leading)
 	return ev, nil
 }
 


### PR DESCRIPTION
## Summary

Deepens the parser's comment handling by replacing four ad hoc, implicit
comment-attachment mechanisms with a single typed `CommentedNode` interface
that the compiler keeps in sync. Observable parse behavior is unchanged —
this is an internal hardening and clarity pass, with new behavioral guards
locking in the existing attribution rules.

## Implementation

- **ast**: Add `CommentedNode` (`CommentSlot() **CommentGroup`), implemented
  by all 39 `Comments`-bearing structs via a one-line method each. A registry
  plus a parity meta-test pins the implementor set at compile time and proves
  it exhaustive against source, so a future `Comments`-bearing struct that
  forgets the method fails the build/test.
- **lexer**: Seal comment mode at construction via `New(src, ...Option)` and
  `WithComments()`; the formerly public `PreserveComments` field is unexported,
  removing a mutable post-construction toggle.
- **parser**: Replace `commentGroupOf`/`attachLeadingComments` with
  `takeLeading` (capture-at-entry) and `bindLeading` (interface dispatch).
  Binding scope is intentionally unchanged — still only top-level definitions
  plus field, input-value, and enum-value definitions; the 18 latent
  commented-node types keep receiving nothing.

## Testing

- New behavioral guards cover definition-vs-field attribution, comments under
  recovery, nested-production attribution, latent-node scope, and
  `bindLeading`'s permissiveness.
- The `ast/comment_test.go` registry + parity meta-test fails if a
  `Comments`-bearing struct is missing the interface method.
- `go test ./...`, `go vet ./...`, and `gofmt -l .` all clean.

## Docs

- `AGENTS.md` and parser option docs updated to describe the
  `CommentedNode` interface and the `takeLeading`/`bindLeading` flow.

Closes #2 