### PR TITLE
Deepen parser loc construction

### DIFF
--- a/parser/document.go
+++ b/parser/document.go
@@ -8,11 +8,10 @@ import (
 // parseDocument consumes the full source and returns a Document containing
 // one or more Definitions. Empty input is an error per spec.
 func (p *parser) parseDocument() (*ast.Document, error) {
-	first, err := p.peek()
+	scope, err := p.enter()
 	if err != nil {
 		return nil, err
 	}
-	start := first.Start
 	var defs ast.DefinitionList
 	for {
 		tok, err := p.peek()
@@ -38,18 +37,18 @@ func (p *parser) parseDocument() (*ast.Document, error) {
 			}
 			se, _ := err.(*ast.SyntaxError)
 			p.skipToDefinitionStart()
-			defs = append(defs, &ast.BadDefinition{Err: se, Loc: p.loc(defStart)})
+			defs = append(defs, &ast.BadDefinition{Err: se, Loc: p.scopeAt(defStart).close()})
 			continue
 		}
 		p.bindLeading(def, defLeading)
 		defs = append(defs, def)
 	}
 	if len(defs) == 0 {
-		return nil, p.errAtTok(first, "Expected at least one definition.")
+		return nil, p.errAtTok(lexer.Token{Start: scope.start}, "Expected at least one definition.")
 	}
 	return &ast.Document{
 		Definitions: defs,
-		Loc:         &ast.Loc{Start: start, End: p.lastEnd, Source: p.source},
+		Loc:         scope.close(),
 	}, nil
 }
 

--- a/parser/document.go
+++ b/parser/document.go
@@ -27,6 +27,7 @@ func (p *parser) parseDocument() (*ast.Document, error) {
 			break
 		}
 		defStart := tok.Start
+		badScope := p.scopeAt(defStart)
 		// Capture the leading-comment buffer for THIS definition before any
 		// inner parser (e.g. its first FieldDefinition) can take it.
 		defLeading := p.takeLeading()
@@ -37,7 +38,7 @@ func (p *parser) parseDocument() (*ast.Document, error) {
 			}
 			se, _ := err.(*ast.SyntaxError)
 			p.skipToDefinitionStart()
-			defs = append(defs, &ast.BadDefinition{Err: se, Loc: p.scopeAt(defStart).close()})
+			defs = append(defs, &ast.BadDefinition{Err: se, Loc: badScope.close()})
 			continue
 		}
 		p.bindLeading(def, defLeading)

--- a/parser/loc_scope_test.go
+++ b/parser/loc_scope_test.go
@@ -1,0 +1,688 @@
+package parser_test
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
+)
+
+func TestLocContainment_ExecutableDocument(t *testing.T) {
+	body := `query GetUser($id: ID! = "1" @varDir, $opts: [Input!] = [{flag: true, size: 3}]) @opDir(enabled: true) {
+  me: user(id: $id, opts: {tags: ["a", null, ADMIN]}) @fieldDir {
+    id
+    ...UserFields @spreadDir
+    ... on Admin @inlineDir { permissions }
+    ... @anonDir { fallback }
+  }
+}
+
+fragment UserFields on User @fragDir { name }`
+
+	doc := mustParse(t, body)
+	assertLocTree(t, body, doc)
+}
+
+func TestLocContainment_SchemaDocument(t *testing.T) {
+	body := `"schema desc"
+schema @schemaDir { query: Query mutation: Mutation subscription: Subscription }
+
+"scalar desc"
+scalar DateTime @specifiedBy(url: "https://example.com/date")
+
+"type desc"
+type Query implements & Node @obj {
+  "field desc"
+  node(
+    "arg desc"
+    id: ID! = "x" @arg
+  ): Node @field
+}
+
+interface Node { id: ID! }
+type Mutation { noop: Boolean }
+type Subscription { tick: Int }
+union Search = Query | Mutation
+enum Color { "red desc" RED @rgb GREEN }
+input Filter { "term desc" term: String = "all" @trim }
+"directive desc"
+directive @example(
+  "input desc"
+  value: String = "x"
+) repeatable on FIELD | QUERY
+extend schema @extra { query: Query }
+extend scalar DateTime @extra
+extend type Query implements Node @extra { extra: String }
+extend interface Node @extra { other: String }
+extend union Search @extra = Subscription
+extend enum Color @extra { BLUE }
+extend input Filter @extra { limit: Int }`
+
+	doc, err := parser.ParseSchema(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLocTree(t, body, doc)
+}
+
+func TestLocContainment_PartialParseRoots(t *testing.T) {
+	valueBody := `{input: [{name: "Ada", ok: true}, null], enum: ADMIN}`
+	value, err := parser.ParseValue(valueBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLocTree(t, valueBody, value)
+
+	constBody := `[1, {field: "value"}]`
+	constValue, err := parser.ParseConstValue(constBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLocTree(t, constBody, constValue)
+
+	typeBody := `[Int!]!`
+	typ, err := parser.ParseType(typeBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLocTree(t, typeBody, typ)
+}
+
+func TestLocWithComments_TopLevelCommentDoesNotWidenDefinition(t *testing.T) {
+	body := `
+# type comment
+type Query { x: Int }`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	assertLocText(t, body, def, `type Query { x: Int }`)
+	if def.Comments == nil || len(def.Comments.Leading) != 1 {
+		t.Fatalf("definition comments = %+v; want one leading comment", def.Comments)
+	}
+	assertLocText(t, body, def.Comments.Leading[0], `# type comment`)
+	assertLocTree(t, body, doc)
+}
+
+func TestLocWithComments_MemberCommentDoesNotWidenParentOrChild(t *testing.T) {
+	body := `type Query {
+  # field comment
+  x: Int
+}`
+	doc, err := parser.Parse(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	field := def.Fields.ForName("x")
+	assertLocText(t, body, def, body)
+	assertLocText(t, body, field, `x: Int`)
+	if def.Comments != nil {
+		t.Fatalf("definition comments = %+v; want nil", def.Comments)
+	}
+	if field.Comments == nil || len(field.Comments.Leading) != 1 {
+		t.Fatalf("field comments = %+v; want one leading comment", field.Comments)
+	}
+	assertLocText(t, body, field.Comments.Leading[0], `# field comment`)
+	assertLocTree(t, body, doc)
+}
+
+func TestLocWithComments_DescriptionsAndCommentsStayOnIntendedNodes(t *testing.T) {
+	body := `# type comment
+"Query description"
+type Query {
+  # field comment
+  "Field description"
+  name: String
+}`
+	doc, err := parser.ParseSchema(body, parser.WithComments())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	field := def.Fields.ForName("name")
+	assertLocText(t, body, def, `"Query description"
+type Query {
+  # field comment
+  "Field description"
+  name: String
+}`)
+	assertLocText(t, body, def.Description, `"Query description"`)
+	assertLocText(t, body, field, `"Field description"
+  name: String`)
+	assertLocText(t, body, field.Description, `"Field description"`)
+	if def.Comments == nil || len(def.Comments.Leading) != 1 {
+		t.Fatalf("definition comments = %+v; want one leading comment", def.Comments)
+	}
+	if field.Comments == nil || len(field.Comments.Leading) != 1 {
+		t.Fatalf("field comments = %+v; want one leading comment", field.Comments)
+	}
+	if def.Comments.Leading[0].Text != " type comment" {
+		t.Fatalf("definition comment = %q; want %q", def.Comments.Leading[0].Text, " type comment")
+	}
+	if field.Comments.Leading[0].Text != " field comment" {
+		t.Fatalf("field comment = %q; want %q", field.Comments.Leading[0].Text, " field comment")
+	}
+	assertLocTree(t, body, doc)
+}
+
+func TestLocWithRecovery_BadDefinitionCoversSkippedRegion(t *testing.T) {
+	body := `bogus_keyword stuff
+query Q { ok }`
+	doc, err := parser.Parse(body, parser.WithRecovery())
+	var parseErrs parser.ParseErrors
+	if !errors.As(err, &parseErrs) {
+		t.Fatalf("err = %T; want parser.ParseErrors", err)
+	}
+	if len(parseErrs) == 0 {
+		t.Fatal("expected at least one parse error")
+	}
+	if len(doc.Definitions) != 2 {
+		t.Fatalf("definitions = %d; want 2", len(doc.Definitions))
+	}
+	bad := doc.Definitions[0].(*ast.BadDefinition)
+	assertLocText(t, body, bad, `bogus_keyword stuff`)
+	assertLocTree(t, body, doc)
+}
+
+func TestLocWithRecovery_BadFieldCoversSkippedRegion(t *testing.T) {
+	body := `{ a $bogus b }`
+	doc, err := parser.Parse(body, parser.WithRecovery())
+	var parseErrs parser.ParseErrors
+	if !errors.As(err, &parseErrs) {
+		t.Fatalf("err = %T; want parser.ParseErrors", err)
+	}
+
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	var bad *ast.BadField
+	for _, sel := range op.SelectionSet.Selections {
+		if b, ok := sel.(*ast.BadField); ok {
+			bad = b
+			break
+		}
+	}
+	if bad == nil {
+		t.Fatal("BadField not found")
+	}
+	assertLocText(t, body, bad, `$`)
+	assertLocTree(t, body, doc)
+}
+
+func TestLocExactSpans_ExecutableEdges(t *testing.T) {
+	operationBody := `query Q($id: ID! = "1" @vd) @op { user: node(id: $id, filter: {tags: ["a", ADMIN]}) @field { ...Frag @spread ... on User @inline { name } ... @anon { id } } }`
+	body := operationBody + ` fragment Frag on User { id }`
+	doc := mustParse(t, body)
+
+	op := doc.Definitions[0].(*ast.OperationDefinition)
+	fragDef := doc.Definitions[1].(*ast.FragmentDefinition)
+	field := op.SelectionSet.Selections[0].(*ast.Field)
+	filterArg := field.Arguments.ForName("filter")
+	objectValue := filterArg.Value.(*ast.ObjectValue)
+	objectField := objectValue.Fields[0]
+	listValue := objectField.Value.(*ast.ListValue)
+	nestedSet := field.SelectionSet
+	fragmentSpread := nestedSet.Selections[0].(*ast.FragmentSpread)
+	inlineWithType := nestedSet.Selections[1].(*ast.InlineFragment)
+	inlineWithoutType := nestedSet.Selections[2].(*ast.InlineFragment)
+
+	assertLocText(t, body, op, operationBody)
+	assertLocText(t, body, op.VariableDefinitions[0], `$id: ID! = "1" @vd`)
+	assertLocText(t, body, op.VariableDefinitions[0].Type, `ID!`)
+	assertLocText(t, body, field, `user: node(id: $id, filter: {tags: ["a", ADMIN]}) @field { ...Frag @spread ... on User @inline { name } ... @anon { id } }`)
+	assertLocText(t, body, filterArg, `filter: {tags: ["a", ADMIN]}`)
+	assertLocText(t, body, objectValue, `{tags: ["a", ADMIN]}`)
+	assertLocText(t, body, objectField, `tags: ["a", ADMIN]`)
+	assertLocText(t, body, listValue, `["a", ADMIN]`)
+	assertLocText(t, body, fragmentSpread, `...Frag @spread`)
+	assertLocText(t, body, inlineWithType, `... on User @inline { name }`)
+	assertLocText(t, body, inlineWithoutType, `... @anon { id }`)
+	assertLocText(t, body, fragDef, `fragment Frag on User { id }`)
+
+	typ, err := parser.ParseType(`[Int!]!`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLocText(t, `[Int!]!`, typ, `[Int!]!`)
+}
+
+func TestLocExactSpans_SchemaEdges(t *testing.T) {
+	body := `"type desc"
+type Query @obj {
+  "field desc"
+  node(
+    "arg desc"
+    id: ID! = "x" @arg
+  ): [Node!]! @field
+}
+"directive desc"
+directive @example(
+  "input desc"
+  value: String = "x"
+) repeatable on FIELD | QUERY
+extend type Query @extra { extra: String }`
+
+	doc, err := parser.ParseSchema(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	objectDef := doc.Definitions[0].(*ast.ObjectTypeDefinition)
+	field := objectDef.Fields.ForName("node")
+	arg := field.Arguments.ForName("id")
+	directiveDef := doc.Definitions[1].(*ast.DirectiveDefinition)
+	extension := doc.Definitions[2].(*ast.ObjectTypeExtension)
+
+	assertLocText(t, body, objectDef, `"type desc"
+type Query @obj {
+  "field desc"
+  node(
+    "arg desc"
+    id: ID! = "x" @arg
+  ): [Node!]! @field
+}`)
+	assertLocText(t, body, field, `"field desc"
+  node(
+    "arg desc"
+    id: ID! = "x" @arg
+  ): [Node!]! @field`)
+	assertLocText(t, body, arg, `"arg desc"
+    id: ID! = "x" @arg`)
+	assertLocText(t, body, arg.Type, `ID!`)
+	assertLocText(t, body, field.Type, `[Node!]!`)
+	assertLocText(t, body, directiveDef, `"directive desc"
+directive @example(
+  "input desc"
+  value: String = "x"
+) repeatable on FIELD | QUERY`)
+	assertLocText(t, body, directiveDef.Arguments.ForName("value"), `"input desc"
+  value: String = "x"`)
+	assertLocText(t, body, extension, `extend type Query @extra { extra: String }`)
+	assertLocText(t, body, extension.Fields.ForName("extra"), `extra: String`)
+}
+
+func assertLocTree(t *testing.T, body string, root ast.Node) {
+	t.Helper()
+	assertLocTreeUnder(t, body, nil, root)
+}
+
+func assertLocTreeUnder(t *testing.T, body string, parent ast.Node, node ast.Node) {
+	t.Helper()
+	if isNilNode(node) {
+		return
+	}
+	loc := node.GetLoc()
+	if loc == nil {
+		t.Fatalf("%T has nil Loc", node)
+	}
+	if loc.Source == nil || loc.Source.Body != body {
+		t.Fatalf("%T Loc.Source = %+v; want source for test body", node, loc.Source)
+	}
+	if loc.Start < 0 || loc.Start > loc.End || loc.End > len(body) {
+		t.Fatalf("%T Loc = [%d, %d), outside body len %d", node, loc.Start, loc.End, len(body))
+	}
+	if parent != nil {
+		parentLoc := parent.GetLoc()
+		if loc.Start < parentLoc.Start || loc.End > parentLoc.End {
+			t.Fatalf("%T Loc [%d, %d) not contained in %T Loc [%d, %d)", node, loc.Start, loc.End, parent, parentLoc.Start, parentLoc.End)
+		}
+	}
+	for _, child := range childrenOf(t, node) {
+		assertLocTreeUnder(t, body, node, child)
+	}
+}
+
+func childrenOf(t *testing.T, node ast.Node) []ast.Node {
+	t.Helper()
+	var children []ast.Node
+	add := func(nodes ...ast.Node) {
+		for _, n := range nodes {
+			if !isNilNode(n) {
+				children = append(children, n)
+			}
+		}
+	}
+
+	switch n := node.(type) {
+	case *ast.Document:
+		for _, def := range n.Definitions {
+			add(def)
+		}
+	case *ast.OperationDefinition:
+		for _, vd := range n.VariableDefinitions {
+			add(vd)
+		}
+		for _, d := range n.Directives {
+			add(d)
+		}
+		add(n.SelectionSet)
+	case *ast.FragmentDefinition:
+		add(n.TypeCondition)
+		for _, d := range n.Directives {
+			add(d)
+		}
+		add(n.SelectionSet)
+	case *ast.VariableDefinition:
+		add(n.Variable, n.Type, n.DefaultValue)
+		for _, d := range n.Directives {
+			add(d)
+		}
+	case *ast.SelectionSet:
+		for _, sel := range n.Selections {
+			add(sel)
+		}
+	case *ast.Field:
+		for _, a := range n.Arguments {
+			add(a)
+		}
+		for _, d := range n.Directives {
+			add(d)
+		}
+		add(n.SelectionSet)
+	case *ast.FragmentSpread:
+		for _, d := range n.Directives {
+			add(d)
+		}
+	case *ast.InlineFragment:
+		add(n.TypeCondition)
+		for _, d := range n.Directives {
+			add(d)
+		}
+		add(n.SelectionSet)
+	case *ast.Argument:
+		add(n.Value)
+	case *ast.Directive:
+		for _, a := range n.Arguments {
+			add(a)
+		}
+	case *ast.ListValue:
+		for _, v := range n.Values {
+			add(v)
+		}
+	case *ast.ObjectValue:
+		for _, f := range n.Fields {
+			add(f)
+		}
+	case *ast.ObjectField:
+		add(n.Value)
+	case *ast.ListType:
+		add(n.OfType)
+	case *ast.NonNullType:
+		add(n.OfType)
+	case *ast.SchemaDefinition:
+		add(n.Description)
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, ot := range n.OperationTypes {
+			add(ot)
+		}
+	case *ast.SchemaExtension:
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, ot := range n.OperationTypes {
+			add(ot)
+		}
+	case *ast.OperationTypeDefinition:
+		add(n.Type)
+	case *ast.ScalarTypeDefinition:
+		add(n.Description)
+		for _, d := range n.Directives {
+			add(d)
+		}
+	case *ast.ScalarTypeExtension:
+		for _, d := range n.Directives {
+			add(d)
+		}
+	case *ast.ObjectTypeDefinition:
+		add(n.Description)
+		for _, i := range n.Interfaces {
+			add(i)
+		}
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, f := range n.Fields {
+			add(f)
+		}
+	case *ast.ObjectTypeExtension:
+		for _, i := range n.Interfaces {
+			add(i)
+		}
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, f := range n.Fields {
+			add(f)
+		}
+	case *ast.InterfaceTypeDefinition:
+		add(n.Description)
+		for _, i := range n.Interfaces {
+			add(i)
+		}
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, f := range n.Fields {
+			add(f)
+		}
+	case *ast.InterfaceTypeExtension:
+		for _, i := range n.Interfaces {
+			add(i)
+		}
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, f := range n.Fields {
+			add(f)
+		}
+	case *ast.UnionTypeDefinition:
+		add(n.Description)
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, m := range n.Members {
+			add(m)
+		}
+	case *ast.UnionTypeExtension:
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, m := range n.Members {
+			add(m)
+		}
+	case *ast.EnumTypeDefinition:
+		add(n.Description)
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, v := range n.Values {
+			add(v)
+		}
+	case *ast.EnumTypeExtension:
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, v := range n.Values {
+			add(v)
+		}
+	case *ast.InputObjectTypeDefinition:
+		add(n.Description)
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, f := range n.Fields {
+			add(f)
+		}
+	case *ast.InputObjectTypeExtension:
+		for _, d := range n.Directives {
+			add(d)
+		}
+		for _, f := range n.Fields {
+			add(f)
+		}
+	case *ast.FieldDefinition:
+		add(n.Description)
+		for _, a := range n.Arguments {
+			add(a)
+		}
+		add(n.Type)
+		for _, d := range n.Directives {
+			add(d)
+		}
+	case *ast.InputValueDefinition:
+		add(n.Description, n.Type, n.DefaultValue)
+		for _, d := range n.Directives {
+			add(d)
+		}
+	case *ast.EnumValueDefinition:
+		add(n.Description)
+		for _, d := range n.Directives {
+			add(d)
+		}
+	case *ast.DirectiveDefinition:
+		add(n.Description)
+		for _, a := range n.Arguments {
+			add(a)
+		}
+	case *ast.IntValue, *ast.FloatValue, *ast.StringValue, *ast.BooleanValue,
+		*ast.NullValue, *ast.EnumValue, *ast.Variable, *ast.NamedType,
+		*ast.Comment, *ast.BadValue, *ast.BadType, *ast.BadField,
+		*ast.BadDefinition:
+	default:
+		t.Fatalf("childrenOf missing AST node type %T", node)
+	}
+	return children
+}
+
+func isNilNode(node ast.Node) bool {
+	if node == nil {
+		return true
+	}
+	switch n := node.(type) {
+	case *ast.Document:
+		return n == nil
+	case *ast.OperationDefinition:
+		return n == nil
+	case *ast.FragmentDefinition:
+		return n == nil
+	case *ast.VariableDefinition:
+		return n == nil
+	case *ast.SelectionSet:
+		return n == nil
+	case *ast.Field:
+		return n == nil
+	case *ast.FragmentSpread:
+		return n == nil
+	case *ast.InlineFragment:
+		return n == nil
+	case *ast.Argument:
+		return n == nil
+	case *ast.Directive:
+		return n == nil
+	case *ast.IntValue:
+		return n == nil
+	case *ast.FloatValue:
+		return n == nil
+	case *ast.StringValue:
+		return n == nil
+	case *ast.BooleanValue:
+		return n == nil
+	case *ast.NullValue:
+		return n == nil
+	case *ast.EnumValue:
+		return n == nil
+	case *ast.ListValue:
+		return n == nil
+	case *ast.ObjectValue:
+		return n == nil
+	case *ast.ObjectField:
+		return n == nil
+	case *ast.Variable:
+		return n == nil
+	case *ast.NamedType:
+		return n == nil
+	case *ast.ListType:
+		return n == nil
+	case *ast.NonNullType:
+		return n == nil
+	case *ast.SchemaDefinition:
+		return n == nil
+	case *ast.SchemaExtension:
+		return n == nil
+	case *ast.OperationTypeDefinition:
+		return n == nil
+	case *ast.ScalarTypeDefinition:
+		return n == nil
+	case *ast.ScalarTypeExtension:
+		return n == nil
+	case *ast.ObjectTypeDefinition:
+		return n == nil
+	case *ast.ObjectTypeExtension:
+		return n == nil
+	case *ast.InterfaceTypeDefinition:
+		return n == nil
+	case *ast.InterfaceTypeExtension:
+		return n == nil
+	case *ast.UnionTypeDefinition:
+		return n == nil
+	case *ast.UnionTypeExtension:
+		return n == nil
+	case *ast.EnumTypeDefinition:
+		return n == nil
+	case *ast.EnumTypeExtension:
+		return n == nil
+	case *ast.InputObjectTypeDefinition:
+		return n == nil
+	case *ast.InputObjectTypeExtension:
+		return n == nil
+	case *ast.FieldDefinition:
+		return n == nil
+	case *ast.InputValueDefinition:
+		return n == nil
+	case *ast.EnumValueDefinition:
+		return n == nil
+	case *ast.DirectiveDefinition:
+		return n == nil
+	case *ast.Comment:
+		return n == nil
+	case *ast.BadValue:
+		return n == nil
+	case *ast.BadType:
+		return n == nil
+	case *ast.BadField:
+		return n == nil
+	case *ast.BadDefinition:
+		return n == nil
+	}
+	return false
+}
+
+func assertLocText(t *testing.T, body string, node ast.Node, want string) {
+	t.Helper()
+	loc := node.GetLoc()
+	if loc == nil {
+		t.Fatalf("%T has nil Loc", node)
+	}
+	if loc.Start < 0 || loc.Start > loc.End || loc.End > len(body) {
+		t.Fatalf("%T Loc = [%d, %d), outside body len %d", node, loc.Start, loc.End, len(body))
+	}
+	got := body[loc.Start:loc.End]
+	if got != want {
+		t.Fatalf("%T Loc text = %s; want %s", node, quoteForLoc(got), quoteForLoc(want))
+	}
+	if idx := strings.Index(body, want); idx >= 0 && (loc.Start != idx || loc.End != idx+len(want)) {
+		t.Fatalf("%T Loc = [%d, %d); want first %q at [%d, %d)", node, loc.Start, loc.End, want, idx, idx+len(want))
+	}
+}
+
+func quoteForLoc(s string) string {
+	return strconv.Quote(s)
+}

--- a/parser/loc_scope_test.go
+++ b/parser/loc_scope_test.go
@@ -3,7 +3,6 @@ package parser_test
 import (
 	"errors"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/brian-bell/graphql-parser/ast"
@@ -677,9 +676,6 @@ func assertLocText(t *testing.T, body string, node ast.Node, want string) {
 	got := body[loc.Start:loc.End]
 	if got != want {
 		t.Fatalf("%T Loc text = %s; want %s", node, quoteForLoc(got), quoteForLoc(want))
-	}
-	if idx := strings.Index(body, want); idx >= 0 && (loc.Start != idx || loc.End != idx+len(want)) {
-		t.Fatalf("%T Loc = [%d, %d); want first %q at [%d, %d)", node, loc.Start, loc.End, want, idx, idx+len(want))
 	}
 }
 

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -126,11 +126,16 @@ func (p *parser) parseFragmentName() (string, error) {
 }
 
 func (p *parser) parseNamedType() (*ast.NamedType, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	scope := p.scopeAt(tok.Start)
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, err
 	}
-	return &ast.NamedType{Name: name.Value, Loc: p.scopeAt(name.Start).close()}, nil
+	return &ast.NamedType{Name: name.Value, Loc: scope.close()}, nil
 }
 
 func (p *parser) parseVariableDefinitions() (ast.VariableDefinitionList, error) {

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -7,11 +7,10 @@ import (
 
 // parseShorthandOperation parses a bare "{ ... }" as an anonymous query.
 func (p *parser) parseShorthandOperation() (*ast.OperationDefinition, error) {
-	tok, err := p.peek()
+	scope, err := p.enter()
 	if err != nil {
 		return nil, err
 	}
-	start := tok.Start
 	set, err := p.parseSelectionSet()
 	if err != nil {
 		return nil, err
@@ -19,7 +18,7 @@ func (p *parser) parseShorthandOperation() (*ast.OperationDefinition, error) {
 	return &ast.OperationDefinition{
 		Operation:    ast.OperationQuery,
 		SelectionSet: set,
-		Loc:          p.loc(start),
+		Loc:          scope.close(),
 	}, nil
 }
 
@@ -30,6 +29,7 @@ func (p *parser) parseOperationDefinition() (*ast.OperationDefinition, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(keyword.Start)
 	op := ast.OperationType(keyword.Value)
 
 	def := &ast.OperationDefinition{Operation: op}
@@ -67,7 +67,7 @@ func (p *parser) parseOperationDefinition() (*ast.OperationDefinition, error) {
 		return nil, err
 	}
 	def.SelectionSet = set
-	def.Loc = p.loc(keyword.Start)
+	def.Loc = scope.close()
 	return def, nil
 }
 
@@ -78,6 +78,7 @@ func (p *parser) parseFragmentDefinition() (*ast.FragmentDefinition, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(keyword.Start)
 	name, err := p.parseFragmentName()
 	if err != nil {
 		return nil, err
@@ -102,7 +103,7 @@ func (p *parser) parseFragmentDefinition() (*ast.FragmentDefinition, error) {
 		TypeCondition: cond,
 		Directives:    dirs,
 		SelectionSet:  set,
-		Loc:           p.loc(keyword.Start),
+		Loc:           scope.close(),
 	}, nil
 }
 
@@ -129,7 +130,7 @@ func (p *parser) parseNamedType() (*ast.NamedType, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ast.NamedType{Name: name.Value, Loc: p.loc(name.Start)}, nil
+	return &ast.NamedType{Name: name.Value, Loc: p.scopeAt(name.Start).close()}, nil
 }
 
 func (p *parser) parseVariableDefinitions() (ast.VariableDefinitionList, error) {
@@ -167,6 +168,7 @@ func (p *parser) parseVariableDefinition() (*ast.VariableDefinition, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(dollar.Start)
 	v, err := p.parseVariable()
 	if err != nil {
 		return nil, err
@@ -193,7 +195,7 @@ func (p *parser) parseVariableDefinition() (*ast.VariableDefinition, error) {
 		return nil, err
 	}
 	def.Directives = dirs
-	def.Loc = p.loc(dollar.Start)
+	def.Loc = scope.close()
 	return def, nil
 }
 
@@ -223,6 +225,7 @@ func (p *parser) parseDirective(isConst bool) (*ast.Directive, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(at.Start)
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, err
@@ -234,7 +237,7 @@ func (p *parser) parseDirective(isConst bool) (*ast.Directive, error) {
 	return &ast.Directive{
 		Name:      name.Value,
 		Arguments: args,
-		Loc:       p.loc(at.Start),
+		Loc:       scope.close(),
 	}, nil
 }
 
@@ -278,6 +281,7 @@ func (p *parser) parseArgument(isConst bool) (*ast.Argument, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(name.Start)
 	if _, err := p.expect(lexer.COLON); err != nil {
 		return nil, err
 	}
@@ -288,6 +292,6 @@ func (p *parser) parseArgument(isConst bool) (*ast.Argument, error) {
 	return &ast.Argument{
 		Name:  name.Value,
 		Value: v,
-		Loc:   p.loc(name.Start),
+		Loc:   scope.close(),
 	}, nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,6 +23,11 @@ type parser struct {
 	pendingLeading []*ast.Comment
 }
 
+type prodScope struct {
+	p     *parser
+	start int
+}
+
 func newParser(src *ast.Source, opts []Option) *parser {
 	cfg := newConfig(opts)
 	var lopts []lexer.Option
@@ -50,6 +55,22 @@ func (p *parser) advance() (lexer.Token, error) {
 	}
 	p.lastEnd = tok.End
 	return tok, nil
+}
+
+func (p *parser) enter() (prodScope, error) {
+	tok, err := p.peek()
+	if err != nil {
+		return prodScope{}, err
+	}
+	return p.scopeAt(tok.Start), nil
+}
+
+func (p *parser) scopeAt(start int) prodScope {
+	return prodScope{p: p, start: start}
+}
+
+func (s prodScope) close() *ast.Loc {
+	return &ast.Loc{Start: s.start, End: s.p.lastEnd, Source: s.p.source}
 }
 
 // expect consumes the next token, returning an error if its kind is not k.
@@ -117,11 +138,6 @@ func (p *parser) expectEOF() error {
 		return p.errAtTok(tok, fmt.Sprintf("Expected <EOF>, found %s.", describeToken(tok)))
 	}
 	return nil
-}
-
-// loc constructs an *ast.Loc covering [start, p.lastEnd).
-func (p *parser) loc(start int) *ast.Loc {
-	return &ast.Loc{Start: start, End: p.lastEnd, Source: p.source}
 }
 
 // errAtTok builds a SyntaxError pointing at a specific token.

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -32,6 +32,7 @@ func (p *parser) parseTypeSystemDefinitionOrExtension() (ast.Definition, bool, e
 	}
 	descStart := tok.Start
 	if tok.Kind == lexer.STRING {
+		scope := p.scopeAt(tok.Start)
 		strTok, err := p.advance()
 		if err != nil {
 			return nil, false, err
@@ -39,7 +40,7 @@ func (p *parser) parseTypeSystemDefinitionOrExtension() (ast.Definition, bool, e
 		desc = &ast.StringValue{
 			Value: strTok.Value,
 			Block: strTok.Block,
-			Loc:   p.scopeAt(strTok.Start).close(),
+			Loc:   scope.close(),
 		}
 		tok, err = p.peek()
 		if err != nil {
@@ -98,6 +99,7 @@ func (p *parser) parseSchemaDefinition(desc *ast.StringValue, descStart int) (as
 	if err != nil {
 		return nil, false, err
 	}
+	scope := p.scopeAt(definitionStart(descStart, kw.Start, desc != nil))
 	dirs, err := p.parseDirectives(true)
 	if err != nil {
 		return nil, false, err
@@ -110,7 +112,7 @@ func (p *parser) parseSchemaDefinition(desc *ast.StringValue, descStart int) (as
 		Description:    desc,
 		Directives:     dirs,
 		OperationTypes: ots,
-		Loc:            p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
+		Loc:            scope.close(),
 	}, true, nil
 }
 
@@ -147,6 +149,7 @@ func (p *parser) parseOperationTypeDefinition() (*ast.OperationTypeDefinition, e
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(op.Start)
 	switch op.Value {
 	case "query", "mutation", "subscription":
 	default:
@@ -162,7 +165,7 @@ func (p *parser) parseOperationTypeDefinition() (*ast.OperationTypeDefinition, e
 	return &ast.OperationTypeDefinition{
 		Operation: ast.OperationType(op.Value),
 		Type:      t,
-		Loc:       p.scopeAt(op.Start).close(),
+		Loc:       scope.close(),
 	}, nil
 }
 
@@ -171,6 +174,7 @@ func (p *parser) parseScalarTypeDefinition(desc *ast.StringValue, descStart int)
 	if err != nil {
 		return nil, false, err
 	}
+	scope := p.scopeAt(definitionStart(descStart, kw.Start, desc != nil))
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, false, err
@@ -183,7 +187,7 @@ func (p *parser) parseScalarTypeDefinition(desc *ast.StringValue, descStart int)
 		Description: desc,
 		Name:        name.Value,
 		Directives:  dirs,
-		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
+		Loc:         scope.close(),
 	}, true, nil
 }
 
@@ -192,6 +196,7 @@ func (p *parser) parseObjectTypeDefinition(desc *ast.StringValue, descStart int)
 	if err != nil {
 		return nil, false, err
 	}
+	scope := p.scopeAt(definitionStart(descStart, kw.Start, desc != nil))
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, false, err
@@ -214,7 +219,7 @@ func (p *parser) parseObjectTypeDefinition(desc *ast.StringValue, descStart int)
 		Interfaces:  ifaces,
 		Directives:  dirs,
 		Fields:      fields,
-		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
+		Loc:         scope.close(),
 	}, true, nil
 }
 
@@ -223,6 +228,7 @@ func (p *parser) parseInterfaceTypeDefinition(desc *ast.StringValue, descStart i
 	if err != nil {
 		return nil, false, err
 	}
+	scope := p.scopeAt(definitionStart(descStart, kw.Start, desc != nil))
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, false, err
@@ -245,7 +251,7 @@ func (p *parser) parseInterfaceTypeDefinition(desc *ast.StringValue, descStart i
 		Interfaces:  ifaces,
 		Directives:  dirs,
 		Fields:      fields,
-		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
+		Loc:         scope.close(),
 	}, true, nil
 }
 
@@ -324,6 +330,11 @@ func (p *parser) parseFieldDefinition() (*ast.FieldDefinition, error) {
 	if err != nil {
 		return nil, err
 	}
+	start := descStart
+	if desc == nil {
+		start = name.Start
+	}
+	scope := p.scopeAt(start)
 	args, err := p.parseArgumentsDefinition()
 	if err != nil {
 		return nil, err
@@ -339,17 +350,13 @@ func (p *parser) parseFieldDefinition() (*ast.FieldDefinition, error) {
 	if err != nil {
 		return nil, err
 	}
-	start := descStart
-	if desc == nil {
-		start = name.Start
-	}
 	fd := &ast.FieldDefinition{
 		Description: desc,
 		Name:        name.Value,
 		Arguments:   args,
 		Type:        t,
 		Directives:  dirs,
-		Loc:         p.scopeAt(start).close(),
+		Loc:         scope.close(),
 	}
 	p.bindLeading(fd, leading)
 	return fd, nil
@@ -400,6 +407,11 @@ func (p *parser) parseInputValueDefinition() (*ast.InputValueDefinition, error) 
 	if err != nil {
 		return nil, err
 	}
+	start := descStart
+	if desc == nil {
+		start = name.Start
+	}
+	scope := p.scopeAt(start)
 	if _, err := p.expect(lexer.COLON); err != nil {
 		return nil, err
 	}
@@ -421,17 +433,13 @@ func (p *parser) parseInputValueDefinition() (*ast.InputValueDefinition, error) 
 	if err != nil {
 		return nil, err
 	}
-	start := descStart
-	if desc == nil {
-		start = name.Start
-	}
 	iv := &ast.InputValueDefinition{
 		Description:  desc,
 		Name:         name.Value,
 		Type:         t,
 		DefaultValue: def,
 		Directives:   dirs,
-		Loc:          p.scopeAt(start).close(),
+		Loc:          scope.close(),
 	}
 	p.bindLeading(iv, leading)
 	return iv, nil
@@ -442,6 +450,7 @@ func (p *parser) parseUnionTypeDefinition(desc *ast.StringValue, descStart int) 
 	if err != nil {
 		return nil, false, err
 	}
+	scope := p.scopeAt(definitionStart(descStart, kw.Start, desc != nil))
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, false, err
@@ -459,7 +468,7 @@ func (p *parser) parseUnionTypeDefinition(desc *ast.StringValue, descStart int) 
 		Name:        name.Value,
 		Directives:  dirs,
 		Members:     members,
-		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
+		Loc:         scope.close(),
 	}, true, nil
 }
 
@@ -495,6 +504,7 @@ func (p *parser) parseEnumTypeDefinition(desc *ast.StringValue, descStart int) (
 	if err != nil {
 		return nil, false, err
 	}
+	scope := p.scopeAt(definitionStart(descStart, kw.Start, desc != nil))
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, false, err
@@ -512,7 +522,7 @@ func (p *parser) parseEnumTypeDefinition(desc *ast.StringValue, descStart int) (
 		Name:        name.Value,
 		Directives:  dirs,
 		Values:      values,
-		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
+		Loc:         scope.close(),
 	}, true, nil
 }
 
@@ -561,6 +571,11 @@ func (p *parser) parseEnumValueDefinition() (*ast.EnumValueDefinition, error) {
 	if err != nil {
 		return nil, err
 	}
+	start := descStart
+	if desc == nil {
+		start = name.Start
+	}
+	scope := p.scopeAt(start)
 	switch name.Value {
 	case "true", "false", "null":
 		return nil, p.errAtTok(name, "Enum value cannot be true, false, or null.")
@@ -569,15 +584,11 @@ func (p *parser) parseEnumValueDefinition() (*ast.EnumValueDefinition, error) {
 	if err != nil {
 		return nil, err
 	}
-	start := descStart
-	if desc == nil {
-		start = name.Start
-	}
 	ev := &ast.EnumValueDefinition{
 		Description: desc,
 		Name:        name.Value,
 		Directives:  dirs,
-		Loc:         p.scopeAt(start).close(),
+		Loc:         scope.close(),
 	}
 	p.bindLeading(ev, leading)
 	return ev, nil
@@ -588,6 +599,7 @@ func (p *parser) parseInputObjectTypeDefinition(desc *ast.StringValue, descStart
 	if err != nil {
 		return nil, false, err
 	}
+	scope := p.scopeAt(definitionStart(descStart, kw.Start, desc != nil))
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, false, err
@@ -605,7 +617,7 @@ func (p *parser) parseInputObjectTypeDefinition(desc *ast.StringValue, descStart
 		Name:        name.Value,
 		Directives:  dirs,
 		Fields:      fields,
-		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
+		Loc:         scope.close(),
 	}, true, nil
 }
 
@@ -649,6 +661,7 @@ func (p *parser) parseDirectiveDefinition(desc *ast.StringValue, descStart int) 
 	if err != nil {
 		return nil, false, err
 	}
+	scope := p.scopeAt(definitionStart(descStart, kw.Start, desc != nil))
 	if _, err := p.expect(lexer.AT); err != nil {
 		return nil, false, err
 	}
@@ -677,7 +690,7 @@ func (p *parser) parseDirectiveDefinition(desc *ast.StringValue, descStart int) 
 		Arguments:   args,
 		Repeatable:  repeatable,
 		Locations:   locs,
-		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
+		Loc:         scope.close(),
 	}, true, nil
 }
 
@@ -717,6 +730,7 @@ func (p *parser) parseOptionalDescription() (*ast.StringValue, int, error) {
 	if tok.Kind != lexer.STRING {
 		return nil, 0, nil
 	}
+	scope := p.scopeAt(tok.Start)
 	str, err := p.advance()
 	if err != nil {
 		return nil, 0, err
@@ -724,7 +738,7 @@ func (p *parser) parseOptionalDescription() (*ast.StringValue, int, error) {
 	return &ast.StringValue{
 		Value: str.Value,
 		Block: str.Block,
-		Loc:   p.scopeAt(str.Start).close(),
+		Loc:   scope.close(),
 	}, str.Start, nil
 }
 
@@ -762,6 +776,7 @@ func (p *parser) parseTypeSystemExtension() (ast.Definition, bool, error) {
 }
 
 func (p *parser) parseSchemaExtension(start int) (ast.Definition, bool, error) {
+	scope := p.scopeAt(start)
 	if _, err := p.expectKeyword("schema"); err != nil {
 		return nil, false, err
 	}
@@ -784,11 +799,12 @@ func (p *parser) parseSchemaExtension(start int) (ast.Definition, bool, error) {
 	return &ast.SchemaExtension{
 		Directives:     dirs,
 		OperationTypes: ots,
-		Loc:            p.scopeAt(start).close(),
+		Loc:            scope.close(),
 	}, true, nil
 }
 
 func (p *parser) parseScalarTypeExtension(start int) (ast.Definition, bool, error) {
+	scope := p.scopeAt(start)
 	if _, err := p.expectKeyword("scalar"); err != nil {
 		return nil, false, err
 	}
@@ -806,11 +822,12 @@ func (p *parser) parseScalarTypeExtension(start int) (ast.Definition, bool, erro
 	return &ast.ScalarTypeExtension{
 		Name:       name.Value,
 		Directives: dirs,
-		Loc:        p.scopeAt(start).close(),
+		Loc:        scope.close(),
 	}, true, nil
 }
 
 func (p *parser) parseObjectTypeExtension(start int) (ast.Definition, bool, error) {
+	scope := p.scopeAt(start)
 	if _, err := p.expectKeyword("type"); err != nil {
 		return nil, false, err
 	}
@@ -838,11 +855,12 @@ func (p *parser) parseObjectTypeExtension(start int) (ast.Definition, bool, erro
 		Interfaces: ifaces,
 		Directives: dirs,
 		Fields:     fields,
-		Loc:        p.scopeAt(start).close(),
+		Loc:        scope.close(),
 	}, true, nil
 }
 
 func (p *parser) parseInterfaceTypeExtension(start int) (ast.Definition, bool, error) {
+	scope := p.scopeAt(start)
 	if _, err := p.expectKeyword("interface"); err != nil {
 		return nil, false, err
 	}
@@ -870,11 +888,12 @@ func (p *parser) parseInterfaceTypeExtension(start int) (ast.Definition, bool, e
 		Interfaces: ifaces,
 		Directives: dirs,
 		Fields:     fields,
-		Loc:        p.scopeAt(start).close(),
+		Loc:        scope.close(),
 	}, true, nil
 }
 
 func (p *parser) parseUnionTypeExtension(start int) (ast.Definition, bool, error) {
+	scope := p.scopeAt(start)
 	if _, err := p.expectKeyword("union"); err != nil {
 		return nil, false, err
 	}
@@ -897,11 +916,12 @@ func (p *parser) parseUnionTypeExtension(start int) (ast.Definition, bool, error
 		Name:       name.Value,
 		Directives: dirs,
 		Members:    members,
-		Loc:        p.scopeAt(start).close(),
+		Loc:        scope.close(),
 	}, true, nil
 }
 
 func (p *parser) parseEnumTypeExtension(start int) (ast.Definition, bool, error) {
+	scope := p.scopeAt(start)
 	if _, err := p.expectKeyword("enum"); err != nil {
 		return nil, false, err
 	}
@@ -924,11 +944,12 @@ func (p *parser) parseEnumTypeExtension(start int) (ast.Definition, bool, error)
 		Name:       name.Value,
 		Directives: dirs,
 		Values:     values,
-		Loc:        p.scopeAt(start).close(),
+		Loc:        scope.close(),
 	}, true, nil
 }
 
 func (p *parser) parseInputObjectTypeExtension(start int) (ast.Definition, bool, error) {
+	scope := p.scopeAt(start)
 	if _, err := p.expectKeyword("input"); err != nil {
 		return nil, false, err
 	}
@@ -951,6 +972,6 @@ func (p *parser) parseInputObjectTypeExtension(start int) (ast.Definition, bool,
 		Name:       name.Value,
 		Directives: dirs,
 		Fields:     fields,
-		Loc:        p.scopeAt(start).close(),
+		Loc:        scope.close(),
 	}, true, nil
 }

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -39,7 +39,7 @@ func (p *parser) parseTypeSystemDefinitionOrExtension() (ast.Definition, bool, e
 		desc = &ast.StringValue{
 			Value: strTok.Value,
 			Block: strTok.Block,
-			Loc:   p.loc(strTok.Start),
+			Loc:   p.scopeAt(strTok.Start).close(),
 		}
 		tok, err = p.peek()
 		if err != nil {
@@ -110,7 +110,7 @@ func (p *parser) parseSchemaDefinition(desc *ast.StringValue, descStart int) (as
 		Description:    desc,
 		Directives:     dirs,
 		OperationTypes: ots,
-		Loc:            p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+		Loc:            p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
 	}, true, nil
 }
 
@@ -162,7 +162,7 @@ func (p *parser) parseOperationTypeDefinition() (*ast.OperationTypeDefinition, e
 	return &ast.OperationTypeDefinition{
 		Operation: ast.OperationType(op.Value),
 		Type:      t,
-		Loc:       p.loc(op.Start),
+		Loc:       p.scopeAt(op.Start).close(),
 	}, nil
 }
 
@@ -183,7 +183,7 @@ func (p *parser) parseScalarTypeDefinition(desc *ast.StringValue, descStart int)
 		Description: desc,
 		Name:        name.Value,
 		Directives:  dirs,
-		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
 	}, true, nil
 }
 
@@ -214,7 +214,7 @@ func (p *parser) parseObjectTypeDefinition(desc *ast.StringValue, descStart int)
 		Interfaces:  ifaces,
 		Directives:  dirs,
 		Fields:      fields,
-		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
 	}, true, nil
 }
 
@@ -245,7 +245,7 @@ func (p *parser) parseInterfaceTypeDefinition(desc *ast.StringValue, descStart i
 		Interfaces:  ifaces,
 		Directives:  dirs,
 		Fields:      fields,
-		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
 	}, true, nil
 }
 
@@ -349,7 +349,7 @@ func (p *parser) parseFieldDefinition() (*ast.FieldDefinition, error) {
 		Arguments:   args,
 		Type:        t,
 		Directives:  dirs,
-		Loc:         p.loc(start),
+		Loc:         p.scopeAt(start).close(),
 	}
 	p.bindLeading(fd, leading)
 	return fd, nil
@@ -431,7 +431,7 @@ func (p *parser) parseInputValueDefinition() (*ast.InputValueDefinition, error) 
 		Type:         t,
 		DefaultValue: def,
 		Directives:   dirs,
-		Loc:          p.loc(start),
+		Loc:          p.scopeAt(start).close(),
 	}
 	p.bindLeading(iv, leading)
 	return iv, nil
@@ -459,7 +459,7 @@ func (p *parser) parseUnionTypeDefinition(desc *ast.StringValue, descStart int) 
 		Name:        name.Value,
 		Directives:  dirs,
 		Members:     members,
-		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
 	}, true, nil
 }
 
@@ -512,7 +512,7 @@ func (p *parser) parseEnumTypeDefinition(desc *ast.StringValue, descStart int) (
 		Name:        name.Value,
 		Directives:  dirs,
 		Values:      values,
-		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
 	}, true, nil
 }
 
@@ -577,7 +577,7 @@ func (p *parser) parseEnumValueDefinition() (*ast.EnumValueDefinition, error) {
 		Description: desc,
 		Name:        name.Value,
 		Directives:  dirs,
-		Loc:         p.loc(start),
+		Loc:         p.scopeAt(start).close(),
 	}
 	p.bindLeading(ev, leading)
 	return ev, nil
@@ -605,7 +605,7 @@ func (p *parser) parseInputObjectTypeDefinition(desc *ast.StringValue, descStart
 		Name:        name.Value,
 		Directives:  dirs,
 		Fields:      fields,
-		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
 	}, true, nil
 }
 
@@ -677,7 +677,7 @@ func (p *parser) parseDirectiveDefinition(desc *ast.StringValue, descStart int) 
 		Arguments:   args,
 		Repeatable:  repeatable,
 		Locations:   locs,
-		Loc:         p.loc(definitionStart(descStart, kw.Start, desc != nil)),
+		Loc:         p.scopeAt(definitionStart(descStart, kw.Start, desc != nil)).close(),
 	}, true, nil
 }
 
@@ -724,7 +724,7 @@ func (p *parser) parseOptionalDescription() (*ast.StringValue, int, error) {
 	return &ast.StringValue{
 		Value: str.Value,
 		Block: str.Block,
-		Loc:   p.loc(str.Start),
+		Loc:   p.scopeAt(str.Start).close(),
 	}, str.Start, nil
 }
 
@@ -784,7 +784,7 @@ func (p *parser) parseSchemaExtension(start int) (ast.Definition, bool, error) {
 	return &ast.SchemaExtension{
 		Directives:     dirs,
 		OperationTypes: ots,
-		Loc:            p.loc(start),
+		Loc:            p.scopeAt(start).close(),
 	}, true, nil
 }
 
@@ -806,7 +806,7 @@ func (p *parser) parseScalarTypeExtension(start int) (ast.Definition, bool, erro
 	return &ast.ScalarTypeExtension{
 		Name:       name.Value,
 		Directives: dirs,
-		Loc:        p.loc(start),
+		Loc:        p.scopeAt(start).close(),
 	}, true, nil
 }
 
@@ -838,7 +838,7 @@ func (p *parser) parseObjectTypeExtension(start int) (ast.Definition, bool, erro
 		Interfaces: ifaces,
 		Directives: dirs,
 		Fields:     fields,
-		Loc:        p.loc(start),
+		Loc:        p.scopeAt(start).close(),
 	}, true, nil
 }
 
@@ -870,7 +870,7 @@ func (p *parser) parseInterfaceTypeExtension(start int) (ast.Definition, bool, e
 		Interfaces: ifaces,
 		Directives: dirs,
 		Fields:     fields,
-		Loc:        p.loc(start),
+		Loc:        p.scopeAt(start).close(),
 	}, true, nil
 }
 
@@ -897,7 +897,7 @@ func (p *parser) parseUnionTypeExtension(start int) (ast.Definition, bool, error
 		Name:       name.Value,
 		Directives: dirs,
 		Members:    members,
-		Loc:        p.loc(start),
+		Loc:        p.scopeAt(start).close(),
 	}, true, nil
 }
 
@@ -924,7 +924,7 @@ func (p *parser) parseEnumTypeExtension(start int) (ast.Definition, bool, error)
 		Name:       name.Value,
 		Directives: dirs,
 		Values:     values,
-		Loc:        p.loc(start),
+		Loc:        p.scopeAt(start).close(),
 	}, true, nil
 }
 
@@ -951,6 +951,6 @@ func (p *parser) parseInputObjectTypeExtension(start int) (ast.Definition, bool,
 		Name:       name.Value,
 		Directives: dirs,
 		Fields:     fields,
-		Loc:        p.loc(start),
+		Loc:        p.scopeAt(start).close(),
 	}, true, nil
 }

--- a/parser/selection.go
+++ b/parser/selection.go
@@ -8,8 +8,11 @@ import (
 // parseSelectionSet parses "{ Selection+ }". An empty selection set is a
 // syntax error per spec.
 func (p *parser) parseSelectionSet() (*ast.SelectionSet, error) {
-	open, err := p.expect(lexer.LBRACE)
+	scope, err := p.enter()
 	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(lexer.LBRACE); err != nil {
 		return nil, err
 	}
 	var sels []ast.Selection
@@ -37,7 +40,7 @@ func (p *parser) parseSelectionSet() (*ast.SelectionSet, error) {
 			}
 			se, _ := err.(*ast.SyntaxError)
 			p.skipToSelectionStart()
-			sels = append(sels, &ast.BadField{Err: se, Loc: p.loc(selStart)})
+			sels = append(sels, &ast.BadField{Err: se, Loc: p.scopeAt(selStart).close()})
 			continue
 		}
 		sels = append(sels, s)
@@ -48,7 +51,7 @@ func (p *parser) parseSelectionSet() (*ast.SelectionSet, error) {
 	if len(sels) == 0 {
 		return nil, p.errAtTok(lexer.Token{Start: p.lastEnd}, "Expected at least one selection.")
 	}
-	return &ast.SelectionSet{Selections: sels, Loc: p.loc(open.Start)}, nil
+	return &ast.SelectionSet{Selections: sels, Loc: scope.close()}, nil
 }
 
 func (p *parser) parseSelection() (ast.Selection, error) {
@@ -68,6 +71,7 @@ func (p *parser) parseField() (*ast.Field, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(first.Start)
 	field := &ast.Field{}
 
 	// If the next token is a colon, the first NAME was an alias.
@@ -109,7 +113,7 @@ func (p *parser) parseField() (*ast.Field, error) {
 		field.SelectionSet = set
 	}
 
-	field.Loc = p.loc(first.Start)
+	field.Loc = scope.close()
 	return field, nil
 }
 
@@ -124,6 +128,7 @@ func (p *parser) parseFragment() (ast.Selection, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(spread.Start)
 	tok, err := p.peek()
 	if err != nil {
 		return nil, err
@@ -149,7 +154,7 @@ func (p *parser) parseFragment() (ast.Selection, error) {
 			TypeCondition: cond,
 			Directives:    dirs,
 			SelectionSet:  set,
-			Loc:           p.loc(spread.Start),
+			Loc:           scope.close(),
 		}, nil
 	}
 	// "...Name" is a FragmentSpread (Name is not "on").
@@ -165,7 +170,7 @@ func (p *parser) parseFragment() (ast.Selection, error) {
 		return &ast.FragmentSpread{
 			Name:       name.Value,
 			Directives: dirs,
-			Loc:        p.loc(spread.Start),
+			Loc:        scope.close(),
 		}, nil
 	}
 	// "...@dir { ... }" or "...{ ... }" is an InlineFragment without TypeCondition.
@@ -181,7 +186,7 @@ func (p *parser) parseFragment() (ast.Selection, error) {
 		return &ast.InlineFragment{
 			Directives:   dirs,
 			SelectionSet: set,
-			Loc:          p.loc(spread.Start),
+			Loc:          scope.close(),
 		}, nil
 	}
 	return nil, p.errAtTok(tok, "Expected fragment spread or inline fragment, found "+describeToken(tok)+".")

--- a/parser/selection.go
+++ b/parser/selection.go
@@ -33,6 +33,7 @@ func (p *parser) parseSelectionSet() (*ast.SelectionSet, error) {
 			return nil, p.errAtTok(tok, "Expected '}', found <EOF>.")
 		}
 		selStart := tok.Start
+		badScope := p.scopeAt(selStart)
 		s, err := p.parseSelection()
 		if err != nil {
 			if !p.recordError(err) {
@@ -40,7 +41,7 @@ func (p *parser) parseSelectionSet() (*ast.SelectionSet, error) {
 			}
 			se, _ := err.(*ast.SyntaxError)
 			p.skipToSelectionStart()
-			sels = append(sels, &ast.BadField{Err: se, Loc: p.scopeAt(selStart).close()})
+			sels = append(sels, &ast.BadField{Err: se, Loc: badScope.close()})
 			continue
 		}
 		sels = append(sels, s)

--- a/parser/type.go
+++ b/parser/type.go
@@ -20,9 +20,10 @@ func (p *parser) parseTypeReference() (ast.Type, error) {
 		return nil, err
 	}
 	var inner ast.Type
+	var scope prodScope
 	switch tok.Kind {
 	case lexer.LBRACKET:
-		scope := p.scopeAt(tok.Start)
+		scope = p.scopeAt(tok.Start)
 		if _, err := p.advance(); err != nil {
 			return nil, err
 		}
@@ -35,7 +36,7 @@ func (p *parser) parseTypeReference() (ast.Type, error) {
 		}
 		inner = &ast.ListType{OfType: of, Loc: scope.close()}
 	case lexer.NAME:
-		scope := p.scopeAt(tok.Start)
+		scope = p.scopeAt(tok.Start)
 		name, err := p.advance()
 		if err != nil {
 			return nil, err
@@ -50,7 +51,7 @@ func (p *parser) parseTypeReference() (ast.Type, error) {
 		return nil, err
 	}
 	if ok {
-		return &ast.NonNullType{OfType: inner, Loc: p.scopeAt(inner.GetLoc().Start).close()}, nil
+		return &ast.NonNullType{OfType: inner, Loc: scope.close()}, nil
 	}
 	return inner, nil
 }

--- a/parser/type.go
+++ b/parser/type.go
@@ -22,8 +22,8 @@ func (p *parser) parseTypeReference() (ast.Type, error) {
 	var inner ast.Type
 	switch tok.Kind {
 	case lexer.LBRACKET:
-		open, err := p.advance()
-		if err != nil {
+		scope := p.scopeAt(tok.Start)
+		if _, err := p.advance(); err != nil {
 			return nil, err
 		}
 		of, err := p.parseTypeReference()
@@ -33,13 +33,14 @@ func (p *parser) parseTypeReference() (ast.Type, error) {
 		if _, err := p.expect(lexer.RBRACKET); err != nil {
 			return nil, err
 		}
-		inner = &ast.ListType{OfType: of, Loc: p.loc(open.Start)}
+		inner = &ast.ListType{OfType: of, Loc: scope.close()}
 	case lexer.NAME:
+		scope := p.scopeAt(tok.Start)
 		name, err := p.advance()
 		if err != nil {
 			return nil, err
 		}
-		inner = &ast.NamedType{Name: name.Value, Loc: p.loc(name.Start)}
+		inner = &ast.NamedType{Name: name.Value, Loc: scope.close()}
 	default:
 		return nil, p.errAtTok(tok, "Expected type, found "+describeToken(tok)+".")
 	}
@@ -49,7 +50,7 @@ func (p *parser) parseTypeReference() (ast.Type, error) {
 		return nil, err
 	}
 	if ok {
-		return &ast.NonNullType{OfType: inner, Loc: p.loc(inner.GetLoc().Start)}, nil
+		return &ast.NonNullType{OfType: inner, Loc: p.scopeAt(inner.GetLoc().Start).close()}, nil
 	}
 	return inner, nil
 }

--- a/parser/value.go
+++ b/parser/value.go
@@ -76,11 +76,12 @@ func (p *parser) parseVariable() (*ast.Variable, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(dollar.Start)
 	name, err := p.expect(lexer.NAME)
 	if err != nil {
 		return nil, err
 	}
-	return &ast.Variable{Name: name.Value, Loc: p.scopeAt(dollar.Start).close()}, nil
+	return &ast.Variable{Name: name.Value, Loc: scope.close()}, nil
 }
 
 func (p *parser) parseListValue(isConst bool) (*ast.ListValue, error) {
@@ -152,6 +153,7 @@ func (p *parser) parseObjectField(isConst bool) (*ast.ObjectField, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := p.scopeAt(name.Start)
 	if _, err := p.expect(lexer.COLON); err != nil {
 		return nil, err
 	}
@@ -159,5 +161,5 @@ func (p *parser) parseObjectField(isConst bool) (*ast.ObjectField, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ast.ObjectField{Name: name.Value, Value: v, Loc: p.scopeAt(name.Start).close()}, nil
+	return &ast.ObjectField{Name: name.Value, Value: v, Loc: scope.close()}, nil
 }

--- a/parser/value.go
+++ b/parser/value.go
@@ -24,37 +24,43 @@ func (p *parser) parseValueLiteral(isConst bool) (ast.Value, error) {
 	case lexer.LBRACE:
 		return p.parseObjectValue(isConst)
 	case lexer.INT:
+		scope := p.scopeAt(tok.Start)
 		if _, err := p.advance(); err != nil {
 			return nil, err
 		}
-		return &ast.IntValue{Value: tok.Value, Loc: p.loc(tok.Start)}, nil
+		return &ast.IntValue{Value: tok.Value, Loc: scope.close()}, nil
 	case lexer.FLOAT:
+		scope := p.scopeAt(tok.Start)
 		if _, err := p.advance(); err != nil {
 			return nil, err
 		}
-		return &ast.FloatValue{Value: tok.Value, Loc: p.loc(tok.Start)}, nil
+		return &ast.FloatValue{Value: tok.Value, Loc: scope.close()}, nil
 	case lexer.STRING:
+		scope := p.scopeAt(tok.Start)
 		if _, err := p.advance(); err != nil {
 			return nil, err
 		}
-		return &ast.StringValue{Value: tok.Value, Block: tok.Block, Loc: p.loc(tok.Start)}, nil
+		return &ast.StringValue{Value: tok.Value, Block: tok.Block, Loc: scope.close()}, nil
 	case lexer.NAME:
 		switch tok.Value {
 		case "true", "false":
+			scope := p.scopeAt(tok.Start)
 			if _, err := p.advance(); err != nil {
 				return nil, err
 			}
-			return &ast.BooleanValue{Value: tok.Value == "true", Loc: p.loc(tok.Start)}, nil
+			return &ast.BooleanValue{Value: tok.Value == "true", Loc: scope.close()}, nil
 		case "null":
+			scope := p.scopeAt(tok.Start)
 			if _, err := p.advance(); err != nil {
 				return nil, err
 			}
-			return &ast.NullValue{Loc: p.loc(tok.Start)}, nil
+			return &ast.NullValue{Loc: scope.close()}, nil
 		default:
+			scope := p.scopeAt(tok.Start)
 			if _, err := p.advance(); err != nil {
 				return nil, err
 			}
-			return &ast.EnumValue{Value: tok.Value, Loc: p.loc(tok.Start)}, nil
+			return &ast.EnumValue{Value: tok.Value, Loc: scope.close()}, nil
 		}
 	case lexer.DOLLAR:
 		if isConst {
@@ -74,12 +80,15 @@ func (p *parser) parseVariable() (*ast.Variable, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ast.Variable{Name: name.Value, Loc: p.loc(dollar.Start)}, nil
+	return &ast.Variable{Name: name.Value, Loc: p.scopeAt(dollar.Start).close()}, nil
 }
 
 func (p *parser) parseListValue(isConst bool) (*ast.ListValue, error) {
-	open, err := p.expect(lexer.LBRACKET)
+	scope, err := p.enter()
 	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(lexer.LBRACKET); err != nil {
 		return nil, err
 	}
 	var values []ast.Value
@@ -103,12 +112,15 @@ func (p *parser) parseListValue(isConst bool) (*ast.ListValue, error) {
 	if _, err := p.expect(lexer.RBRACKET); err != nil {
 		return nil, err
 	}
-	return &ast.ListValue{Values: values, Loc: p.loc(open.Start)}, nil
+	return &ast.ListValue{Values: values, Loc: scope.close()}, nil
 }
 
 func (p *parser) parseObjectValue(isConst bool) (*ast.ObjectValue, error) {
-	open, err := p.expect(lexer.LBRACE)
+	scope, err := p.enter()
 	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(lexer.LBRACE); err != nil {
 		return nil, err
 	}
 	var fields []*ast.ObjectField
@@ -132,7 +144,7 @@ func (p *parser) parseObjectValue(isConst bool) (*ast.ObjectValue, error) {
 	if _, err := p.expect(lexer.RBRACE); err != nil {
 		return nil, err
 	}
-	return &ast.ObjectValue{Fields: fields, Loc: p.loc(open.Start)}, nil
+	return &ast.ObjectValue{Fields: fields, Loc: scope.close()}, nil
 }
 
 func (p *parser) parseObjectField(isConst bool) (*ast.ObjectField, error) {
@@ -147,5 +159,5 @@ func (p *parser) parseObjectField(isConst bool) (*ast.ObjectField, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ast.ObjectField{Name: name.Value, Value: v, Loc: p.loc(name.Start)}, nil
+	return &ast.ObjectField{Name: name.Value, Value: v, Loc: p.scopeAt(name.Start).close()}, nil
 }


### PR DESCRIPTION
## Summary

Deepens parser `Loc` construction so node spans are scoped to their full grammar production instead of being anchored to incidental parser state. Adds characterization coverage for parser location spans across executable definitions, SDL definitions and extensions, values, types, comments, and recovery paths.

Closes #3.

## Implementation notes

- Threads explicit production start offsets through parser helpers before constructing AST nodes.
- Tightens location construction in document, operation, selection, schema, type, and value parsing.
- Adds `parser/loc_scope_test.go` with focused span assertions, including comments-on behavior and recovery bad-node spans.

## Verification

Previously run in this flow:

- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- focused parser location/comment/recovery tests
- `TestCorpus` / `TestParseSchema`
- performance and final location-construction greps
