### PR TITLE
Add reusable parser entry points

### DIFF
--- a/parser/api.go
+++ b/parser/api.go
@@ -206,9 +206,31 @@ func (p *Parser) parseValue(src *ast.Source, isConst bool) (ast.Value, error) {
 func partialEntryStart(p *parser) int {
 	tok, err := p.peek()
 	if err != nil {
-		return 0
+		return firstNonIgnoredOffset(p.source.Body)
 	}
 	return tok.Start
+}
+
+func firstNonIgnoredOffset(body string) int {
+	for pos := 0; pos < len(body); {
+		switch body[pos] {
+		case ' ', '\t', ',', '\n', '\r':
+			pos++
+		case 0xEF:
+			if pos+2 < len(body) && body[pos+1] == 0xBB && body[pos+2] == 0xBF {
+				pos += 3
+				continue
+			}
+			return pos
+		case '#':
+			for pos < len(body) && body[pos] != '\n' && body[pos] != '\r' {
+				pos++
+			}
+		default:
+			return pos
+		}
+	}
+	return len(body)
 }
 
 func (p *parser) partialEntryLoc(start int) *ast.Loc {

--- a/parser/api.go
+++ b/parser/api.go
@@ -58,6 +58,9 @@ func (p *Parser) parseSource(src *ast.Source) (*ast.Document, *parser, error) {
 	if err != nil {
 		if internal.cfg.recovery {
 			_ = internal.recordError(err)
+			if doc == nil {
+				internal.skipToEOF()
+			}
 		} else {
 			return nil, internal, err
 		}

--- a/parser/api.go
+++ b/parser/api.go
@@ -2,18 +2,32 @@ package parser
 
 import "github.com/brian-bell/graphql-parser/ast"
 
+// Parser is a reusable parse entry point configured by [Option] values.
+//
+// A Parser stores only immutable parse configuration. Each parse method creates
+// a fresh internal lexer/parser, so one Parser can be reused across calls
+// without leaking source, comment, recovery, or error state.
+type Parser struct {
+	cfg config
+}
+
+// New returns a reusable Parser configured by opts.
+func New(opts ...Option) *Parser {
+	return &Parser{cfg: *newConfig(opts)}
+}
+
 // Parse parses a GraphQL source document and returns its [ast.Document].
 // The source is wrapped in an ast.Source named "GraphQL" for error messages;
 // use [ParseSource] to supply your own filename and location offset.
 func Parse(body string, opts ...Option) (*ast.Document, error) {
-	return ParseSource(&ast.Source{Body: body, Name: "GraphQL"}, opts...)
+	return New(opts...).Parse(&ast.Source{Body: body, Name: "GraphQL"})
 }
 
 // ParseSchema parses a GraphQL schema document and returns its [ast.Document].
 // The source is wrapped in an ast.Source named "GraphQL" for error messages;
 // use [ParseSchemaSource] to supply your own filename and location offset.
 func ParseSchema(body string, opts ...Option) (*ast.Document, error) {
-	return ParseSchemaSource(&ast.Source{Body: body, Name: "GraphQL"}, opts...)
+	return New(opts...).ParseSchema(&ast.Source{Body: body, Name: "GraphQL"})
 }
 
 // ParseSource parses a GraphQL document from src.
@@ -24,36 +38,51 @@ func ParseSchema(body string, opts ...Option) (*ast.Document, error) {
 // non-nil [ParseErrors]; the document may contain Bad{Definition,Field,Value,
 // Type} placeholder nodes where the parser had to resynchronize.
 func ParseSource(src *ast.Source, opts ...Option) (*ast.Document, error) {
-	doc, _, err := parseSource(src, opts)
+	return New(opts...).Parse(src)
+}
+
+// Parse parses a GraphQL document from src.
+//
+// In the default fail-fast mode the first syntax error aborts and the
+// returned *ast.Document is nil. With [WithRecovery], the parser collects
+// every syntax error it encounters and returns a partial document plus a
+// non-nil [ParseErrors].
+func (p *Parser) Parse(src *ast.Source) (*ast.Document, error) {
+	doc, _, err := p.parseSource(src)
 	return doc, err
 }
 
-func parseSource(src *ast.Source, opts []Option) (*ast.Document, *parser, error) {
-	p := newParser(src, opts)
-	doc, err := p.parseDocument()
+func (p *Parser) parseSource(src *ast.Source) (*ast.Document, *parser, error) {
+	internal := newParserWithConfig(src, p.cfg)
+	doc, err := internal.parseDocument()
 	if err != nil {
-		if p.cfg.recovery {
-			_ = p.recordError(err)
+		if internal.cfg.recovery {
+			_ = internal.recordError(err)
 		} else {
-			return nil, p, err
+			return nil, internal, err
 		}
 	}
-	if err := p.expectEOF(); err != nil {
-		if !p.cfg.recovery {
-			return nil, p, err
+	if err := internal.expectEOF(); err != nil {
+		if !internal.cfg.recovery {
+			return nil, internal, err
 		}
-		_ = p.recordError(err)
+		_ = internal.recordError(err)
 	}
-	if p.cfg.recovery && len(p.errors) > 0 {
-		return doc, p, ParseErrors(p.errors)
+	if internal.cfg.recovery && len(internal.errors) > 0 {
+		return doc, internal, ParseErrors(internal.errors)
 	}
-	return doc, p, nil
+	return doc, internal, nil
 }
 
 // ParseSchemaSource parses a GraphQL schema document from src.
 func ParseSchemaSource(src *ast.Source, opts ...Option) (*ast.Document, error) {
-	doc, p, err := parseSource(src, opts)
-	if err != nil && !p.cfg.recovery {
+	return New(opts...).ParseSchema(src)
+}
+
+// ParseSchema parses a GraphQL schema document from src.
+func (p *Parser) ParseSchema(src *ast.Source) (*ast.Document, error) {
+	doc, internal, err := p.parseSource(src)
+	if err != nil && !internal.cfg.recovery {
 		return nil, err
 	}
 	if doc == nil {
@@ -64,11 +93,11 @@ func ParseSchemaSource(src *ast.Source, opts ...Option) (*ast.Document, error) {
 	if len(schemaErrs) == 0 {
 		return doc, err
 	}
-	if !p.cfg.recovery {
+	if !internal.cfg.recovery {
 		return nil, schemaErrs[0]
 	}
-	p.errors = append(p.errors, schemaErrs...)
-	return doc, ParseErrors(p.errors)
+	internal.errors = append(internal.errors, schemaErrs...)
+	return doc, ParseErrors(internal.errors)
 }
 
 func schemaOnlyErrors(doc *ast.Document) []*ast.SyntaxError {
@@ -96,39 +125,93 @@ func schemaOnlyErrors(doc *ast.Document) []*ast.SyntaxError {
 // ParseValue parses a single GraphQL value literal. Variables ($name) are
 // allowed; for the const-context grammar use [ParseConstValue].
 func ParseValue(body string, opts ...Option) (ast.Value, error) {
-	return parseValueEntry(body, false, opts)
+	return New(opts...).ParseValue(&ast.Source{Body: body, Name: "GraphQL"})
 }
 
 // ParseConstValue parses a single GraphQL const value literal. Variables
 // ($name) are rejected at any nesting depth.
 func ParseConstValue(body string, opts ...Option) (ast.Value, error) {
-	return parseValueEntry(body, true, opts)
+	return New(opts...).ParseConstValue(&ast.Source{Body: body, Name: "GraphQL"})
 }
 
 // ParseType parses a single GraphQL type reference (NamedType, ListType, or
 // NonNullType).
 func ParseType(body string, opts ...Option) (ast.Type, error) {
-	src := &ast.Source{Body: body, Name: "GraphQL"}
-	p := newParser(src, opts)
-	t, err := p.parseTypeReference()
+	return New(opts...).ParseType(&ast.Source{Body: body, Name: "GraphQL"})
+}
+
+// ParseValue parses a single GraphQL value literal from src. Variables
+// ($name) are allowed; for the const-context grammar use [Parser.ParseConstValue].
+func (p *Parser) ParseValue(src *ast.Source) (ast.Value, error) {
+	return p.parseValue(src, false)
+}
+
+// ParseConstValue parses a single GraphQL const value literal from src.
+// Variables ($name) are rejected at any nesting depth.
+func (p *Parser) ParseConstValue(src *ast.Source) (ast.Value, error) {
+	return p.parseValue(src, true)
+}
+
+// ParseType parses a single GraphQL type reference (NamedType, ListType, or
+// NonNullType) from src.
+func (p *Parser) ParseType(src *ast.Source) (ast.Type, error) {
+	internal := newParserWithConfig(src, p.cfg)
+	start := partialEntryStart(internal)
+	t, err := internal.parseTypeReference()
 	if err != nil {
+		if internal.recordError(err) {
+			se, _ := err.(*ast.SyntaxError)
+			internal.skipToEOF()
+			return &ast.BadType{Err: se, Loc: internal.partialEntryLoc(start)}, ParseErrors(internal.errors)
+		}
 		return nil, err
 	}
-	if err := p.expectEOF(); err != nil {
+	if err := internal.expectEOF(); err != nil {
+		if internal.recordError(err) {
+			se, _ := err.(*ast.SyntaxError)
+			internal.skipToEOF()
+			return &ast.BadType{Err: se, Loc: internal.partialEntryLoc(start)}, ParseErrors(internal.errors)
+		}
 		return nil, err
 	}
 	return t, nil
 }
 
-func parseValueEntry(body string, isConst bool, opts []Option) (ast.Value, error) {
-	src := &ast.Source{Body: body, Name: "GraphQL"}
-	p := newParser(src, opts)
-	v, err := p.parseValueLiteral(isConst)
+func (p *Parser) parseValue(src *ast.Source, isConst bool) (ast.Value, error) {
+	internal := newParserWithConfig(src, p.cfg)
+	start := partialEntryStart(internal)
+	v, err := internal.parseValueLiteral(isConst)
 	if err != nil {
+		if internal.recordError(err) {
+			se, _ := err.(*ast.SyntaxError)
+			internal.skipToEOF()
+			return &ast.BadValue{Err: se, Loc: internal.partialEntryLoc(start)}, ParseErrors(internal.errors)
+		}
 		return nil, err
 	}
-	if err := p.expectEOF(); err != nil {
+	if err := internal.expectEOF(); err != nil {
+		if internal.recordError(err) {
+			se, _ := err.(*ast.SyntaxError)
+			internal.skipToEOF()
+			return &ast.BadValue{Err: se, Loc: internal.partialEntryLoc(start)}, ParseErrors(internal.errors)
+		}
 		return nil, err
 	}
 	return v, nil
+}
+
+func partialEntryStart(p *parser) int {
+	tok, err := p.peek()
+	if err != nil {
+		return 0
+	}
+	return tok.Start
+}
+
+func (p *parser) partialEntryLoc(start int) *ast.Loc {
+	end := p.lastEnd
+	if end < start {
+		end = start
+	}
+	return &ast.Loc{Start: start, End: end, Source: p.source}
 }

--- a/parser/api_test.go
+++ b/parser/api_test.go
@@ -471,6 +471,69 @@ func TestParserValueAndTypeRecoveryTreatsNestedFailureAsRootFailure(t *testing.T
 	})
 }
 
+func TestParserValueAndTypeRecoveryConsumesLexerErrors(t *testing.T) {
+	p := parser.New(parser.WithRecovery())
+
+	valueBodies := []string{"?", "01", "-", "\"unterminated"}
+	for _, body := range valueBodies {
+		t.Run("value/"+body, func(t *testing.T) {
+			src := &ast.Source{Body: body, Name: "value-lexer-error.graphql"}
+			v, err := p.ParseValue(src)
+			assertParseErrors(t, err, 1)
+			bad, ok := v.(*ast.BadValue)
+			if !ok {
+				t.Fatalf("value = %T; want *ast.BadValue", v)
+			}
+			assertBadLoc(t, bad.Err, bad.Loc, src, 0, len(src.Body))
+		})
+
+		t.Run("const value/"+body, func(t *testing.T) {
+			src := &ast.Source{Body: body, Name: "const-value-lexer-error.graphql"}
+			v, err := p.ParseConstValue(src)
+			assertParseErrors(t, err, 1)
+			bad, ok := v.(*ast.BadValue)
+			if !ok {
+				t.Fatalf("const value = %T; want *ast.BadValue", v)
+			}
+			assertBadLoc(t, bad.Err, bad.Loc, src, 0, len(src.Body))
+		})
+	}
+
+	typeBodies := []string{"?", "01", "-", "\"unterminated"}
+	for _, body := range typeBodies {
+		t.Run("type/"+body, func(t *testing.T) {
+			src := &ast.Source{Body: body, Name: "type-lexer-error.graphql"}
+			typ, err := p.ParseType(src)
+			assertParseErrors(t, err, 1)
+			bad, ok := typ.(*ast.BadType)
+			if !ok {
+				t.Fatalf("type = %T; want *ast.BadType", typ)
+			}
+			assertBadLoc(t, bad.Err, bad.Loc, src, 0, len(src.Body))
+		})
+	}
+}
+
+func TestDocumentRecoveryConsumesInitialLexerErrorsOnce(t *testing.T) {
+	p := parser.New(parser.WithRecovery())
+
+	t.Run("document", func(t *testing.T) {
+		doc, err := p.Parse(&ast.Source{Body: "?", Name: "doc-lexer-error.graphql"})
+		if doc != nil {
+			t.Fatalf("document = %T; want nil", doc)
+		}
+		assertParseErrors(t, err, 1)
+	})
+
+	t.Run("schema", func(t *testing.T) {
+		doc, err := p.ParseSchema(&ast.Source{Body: "?", Name: "schema-lexer-error.graphql"})
+		if doc != nil {
+			t.Fatalf("schema document = %T; want nil", doc)
+		}
+		assertParseErrors(t, err, 1)
+	})
+}
+
 func assertLocSource(t *testing.T, loc *ast.Loc, src *ast.Source) {
 	t.Helper()
 	if loc == nil {

--- a/parser/api_test.go
+++ b/parser/api_test.go
@@ -514,6 +514,45 @@ func TestParserValueAndTypeRecoveryConsumesLexerErrors(t *testing.T) {
 	}
 }
 
+func TestParserValueAndTypeRecoveryStartsAtFirstNonIgnoredLexerError(t *testing.T) {
+	p := parser.New(parser.WithRecovery())
+	body := "  ?"
+	wantStart := 2
+
+	t.Run("value", func(t *testing.T) {
+		src := &ast.Source{Body: body, Name: "value-leading-lexer-error.graphql"}
+		v, err := p.ParseValue(src)
+		assertParseErrors(t, err, 1)
+		bad, ok := v.(*ast.BadValue)
+		if !ok {
+			t.Fatalf("value = %T; want *ast.BadValue", v)
+		}
+		assertBadLoc(t, bad.Err, bad.Loc, src, wantStart, len(src.Body))
+	})
+
+	t.Run("const value", func(t *testing.T) {
+		src := &ast.Source{Body: body, Name: "const-value-leading-lexer-error.graphql"}
+		v, err := p.ParseConstValue(src)
+		assertParseErrors(t, err, 1)
+		bad, ok := v.(*ast.BadValue)
+		if !ok {
+			t.Fatalf("const value = %T; want *ast.BadValue", v)
+		}
+		assertBadLoc(t, bad.Err, bad.Loc, src, wantStart, len(src.Body))
+	})
+
+	t.Run("type", func(t *testing.T) {
+		src := &ast.Source{Body: body, Name: "type-leading-lexer-error.graphql"}
+		typ, err := p.ParseType(src)
+		assertParseErrors(t, err, 1)
+		bad, ok := typ.(*ast.BadType)
+		if !ok {
+			t.Fatalf("type = %T; want *ast.BadType", typ)
+		}
+		assertBadLoc(t, bad.Err, bad.Loc, src, wantStart, len(src.Body))
+	})
+}
+
 func TestDocumentRecoveryConsumesInitialLexerErrorsOnce(t *testing.T) {
 	p := parser.New(parser.WithRecovery())
 

--- a/parser/api_test.go
+++ b/parser/api_test.go
@@ -517,21 +517,23 @@ func TestParserValueAndTypeRecoveryConsumesLexerErrors(t *testing.T) {
 func TestDocumentRecoveryConsumesInitialLexerErrorsOnce(t *testing.T) {
 	p := parser.New(parser.WithRecovery())
 
-	t.Run("document", func(t *testing.T) {
-		doc, err := p.Parse(&ast.Source{Body: "?", Name: "doc-lexer-error.graphql"})
-		if doc != nil {
-			t.Fatalf("document = %T; want nil", doc)
-		}
-		assertParseErrors(t, err, 1)
-	})
+	for _, body := range []string{"?", "01"} {
+		t.Run("document/"+body, func(t *testing.T) {
+			doc, err := p.Parse(&ast.Source{Body: body, Name: "doc-lexer-error.graphql"})
+			if doc != nil {
+				t.Fatalf("document = %T; want nil", doc)
+			}
+			assertParseErrors(t, err, 1)
+		})
 
-	t.Run("schema", func(t *testing.T) {
-		doc, err := p.ParseSchema(&ast.Source{Body: "?", Name: "schema-lexer-error.graphql"})
-		if doc != nil {
-			t.Fatalf("schema document = %T; want nil", doc)
-		}
-		assertParseErrors(t, err, 1)
-	})
+		t.Run("schema/"+body, func(t *testing.T) {
+			doc, err := p.ParseSchema(&ast.Source{Body: body, Name: "schema-lexer-error.graphql"})
+			if doc != nil {
+				t.Fatalf("schema document = %T; want nil", doc)
+			}
+			assertParseErrors(t, err, 1)
+		})
+	}
 }
 
 func assertLocSource(t *testing.T, loc *ast.Loc, src *ast.Source) {

--- a/parser/api_test.go
+++ b/parser/api_test.go
@@ -1,0 +1,511 @@
+package parser_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
+)
+
+var (
+	_ func(string, ...parser.Option) (*ast.Document, error)      = parser.Parse
+	_ func(string, ...parser.Option) (*ast.Document, error)      = parser.ParseSchema
+	_ func(*ast.Source, ...parser.Option) (*ast.Document, error) = parser.ParseSource
+	_ func(*ast.Source, ...parser.Option) (*ast.Document, error) = parser.ParseSchemaSource
+	_ func(string, ...parser.Option) (ast.Value, error)          = parser.ParseValue
+	_ func(string, ...parser.Option) (ast.Value, error)          = parser.ParseConstValue
+	_ func(string, ...parser.Option) (ast.Type, error)           = parser.ParseType
+	_ func(...parser.Option) *parser.Parser                      = parser.New
+)
+
+func TestParserReuseDoesNotLeakState(t *testing.T) {
+	p := parser.New(parser.WithComments(), parser.WithRecovery())
+
+	first, err := p.Parse(&ast.Source{Body: "# leading\nquery First { one }", Name: "first.graphql"})
+	if err != nil {
+		t.Fatalf("first Parse returned error: %v", err)
+	}
+	if len(first.Definitions) != 1 {
+		t.Fatalf("first definition count = %d; want 1", len(first.Definitions))
+	}
+	if comments := first.Definitions[0].(ast.CommentedNode).CommentSlot(); comments == nil || *comments == nil || len((*comments).Leading) != 1 {
+		t.Fatalf("first definition did not receive its leading comment")
+	}
+
+	bad, err := p.Parse(&ast.Source{Body: "query Bad { ... }", Name: "bad.graphql"})
+	if err == nil {
+		t.Fatal("bad Parse returned nil error")
+	}
+	if bad == nil {
+		t.Fatal("bad Parse returned nil document in recovery mode")
+	}
+	var errs parser.ParseErrors
+	if !errors.As(err, &errs) || len(errs) == 0 {
+		t.Fatalf("bad Parse error = %T; want non-empty parser.ParseErrors", err)
+	}
+
+	v, err := p.ParseValue(&ast.Source{Body: "$x", Name: "value.graphql"})
+	if err != nil {
+		t.Fatalf("ParseValue after recovered document returned error: %v", err)
+	}
+	if variable, ok := v.(*ast.Variable); !ok || variable.Name != "x" {
+		t.Fatalf("ParseValue after recovered document = %T; want variable $x", v)
+	}
+
+	second, err := p.Parse(&ast.Source{Body: "query Second { two }", Name: "second.graphql"})
+	if err != nil {
+		t.Fatalf("second Parse returned leaked error: %v", err)
+	}
+	if comments := second.Definitions[0].(ast.CommentedNode).CommentSlot(); comments != nil && *comments != nil {
+		t.Fatalf("second definition received leaked comments: %#v", *comments)
+	}
+}
+
+func TestParserMethodsPreserveSourceMetadata(t *testing.T) {
+	p := parser.New()
+
+	t.Run("document", func(t *testing.T) {
+		src := &ast.Source{Body: "query Get { field }", Name: "doc.graphql", LocationOffset: ast.Position{Line: 10, Column: 4}}
+		doc, err := p.Parse(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertLocSource(t, doc.Loc, src)
+	})
+
+	t.Run("schema", func(t *testing.T) {
+		src := &ast.Source{Body: "type User { id: ID }", Name: "schema.graphql", LocationOffset: ast.Position{Line: 20, Column: 7}}
+		doc, err := p.ParseSchema(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertLocSource(t, doc.Loc, src)
+	})
+
+	t.Run("value", func(t *testing.T) {
+		src := &ast.Source{Body: "{name: \"Ada\"}", Name: "value.graphql", LocationOffset: ast.Position{Line: 30, Column: 2}}
+		v, err := p.ParseValue(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertLocSource(t, v.GetLoc(), src)
+	})
+
+	t.Run("const value", func(t *testing.T) {
+		src := &ast.Source{Body: "[1, 2, 3]", Name: "const-value.graphql", LocationOffset: ast.Position{Line: 40, Column: 9}}
+		v, err := p.ParseConstValue(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertLocSource(t, v.GetLoc(), src)
+	})
+
+	t.Run("type", func(t *testing.T) {
+		src := &ast.Source{Body: "[User!]!", Name: "type.graphql", LocationOffset: ast.Position{Line: 50, Column: 3}}
+		typ, err := p.ParseType(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertLocSource(t, typ.GetLoc(), src)
+	})
+}
+
+func TestParserMethodErrorsPreserveSourceMetadata(t *testing.T) {
+	p := parser.New()
+	cases := []struct {
+		name  string
+		src   *ast.Source
+		parse func(*ast.Source) error
+	}{
+		{
+			name: "document",
+			src:  &ast.Source{Body: "query", Name: "doc-error.graphql", LocationOffset: ast.Position{Line: 3, Column: 5}},
+			parse: func(src *ast.Source) error {
+				_, err := p.Parse(src)
+				return err
+			},
+		},
+		{
+			name: "schema",
+			src:  &ast.Source{Body: "query", Name: "schema-error.graphql", LocationOffset: ast.Position{Line: 4, Column: 6}},
+			parse: func(src *ast.Source) error {
+				_, err := p.ParseSchema(src)
+				return err
+			},
+		},
+		{
+			name: "value",
+			src:  &ast.Source{Body: "!", Name: "value-error.graphql", LocationOffset: ast.Position{Line: 5, Column: 7}},
+			parse: func(src *ast.Source) error {
+				_, err := p.ParseValue(src)
+				return err
+			},
+		},
+		{
+			name: "const value",
+			src:  &ast.Source{Body: "$x", Name: "const-value-error.graphql", LocationOffset: ast.Position{Line: 6, Column: 8}},
+			parse: func(src *ast.Source) error {
+				_, err := p.ParseConstValue(src)
+				return err
+			},
+		},
+		{
+			name: "type",
+			src:  &ast.Source{Body: "!", Name: "type-error.graphql", LocationOffset: ast.Position{Line: 7, Column: 9}},
+			parse: func(src *ast.Source) error {
+				_, err := p.ParseType(src)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.parse(tc.src)
+			if err == nil {
+				t.Fatal("parse returned nil error")
+			}
+			var syntaxErr *parser.ParseError
+			if !errors.As(err, &syntaxErr) {
+				t.Fatalf("error = %T; want *parser.ParseError", err)
+			}
+			if syntaxErr.Source != tc.src {
+				t.Fatalf("error source = %p; want %p", syntaxErr.Source, tc.src)
+			}
+			if pos := syntaxErr.Position(); pos.Line != tc.src.LocationOffset.Line {
+				t.Fatalf("error line = %d; want shifted line %d", pos.Line, tc.src.LocationOffset.Line)
+			}
+		})
+	}
+}
+
+func TestParserNewNilOptionsMatchesPackageHelpers(t *testing.T) {
+	p := parser.New(nil)
+
+	doc, err := p.Parse(&ast.Source{Body: "query Get { field }", Name: "custom.graphql"})
+	if err != nil {
+		t.Fatalf("Parser.Parse returned error: %v", err)
+	}
+	compatDoc, err := parser.Parse("query Get { field }", nil)
+	if err != nil {
+		t.Fatalf("parser.Parse returned error: %v", err)
+	}
+	if len(doc.Definitions) != len(compatDoc.Definitions) {
+		t.Fatalf("definition count = %d; want %d", len(doc.Definitions), len(compatDoc.Definitions))
+	}
+
+	value, err := p.ParseValue(&ast.Source{Body: "123", Name: "value.graphql"})
+	if err != nil {
+		t.Fatalf("Parser.ParseValue returned error: %v", err)
+	}
+	compatValue, err := parser.ParseValue("123", nil)
+	if err != nil {
+		t.Fatalf("parser.ParseValue returned error: %v", err)
+	}
+	if value.GetLoc().End != compatValue.GetLoc().End {
+		t.Fatalf("value end = %d; want %d", value.GetLoc().End, compatValue.GetLoc().End)
+	}
+}
+
+func TestParserValueAndTypeRecoveryReturnsRootBadNodes(t *testing.T) {
+	p := parser.New(parser.WithRecovery())
+
+	t.Run("value", func(t *testing.T) {
+		src := &ast.Source{Body: "!", Name: "value-recovery.graphql"}
+		v, err := p.ParseValue(src)
+		assertParseErrors(t, err, 1)
+		bad, ok := v.(*ast.BadValue)
+		if !ok {
+			t.Fatalf("value = %T; want *ast.BadValue", v)
+		}
+		assertBadLoc(t, bad.Err, bad.Loc, src, 0, 1)
+	})
+
+	t.Run("const value", func(t *testing.T) {
+		src := &ast.Source{Body: "$x", Name: "const-value-recovery.graphql"}
+		v, err := p.ParseConstValue(src)
+		assertParseErrors(t, err, 1)
+		bad, ok := v.(*ast.BadValue)
+		if !ok {
+			t.Fatalf("const value = %T; want *ast.BadValue", v)
+		}
+		assertBadLoc(t, bad.Err, bad.Loc, src, 0, 2)
+	})
+
+	t.Run("type", func(t *testing.T) {
+		src := &ast.Source{Body: "!", Name: "type-recovery.graphql"}
+		typ, err := p.ParseType(src)
+		assertParseErrors(t, err, 1)
+		bad, ok := typ.(*ast.BadType)
+		if !ok {
+			t.Fatalf("type = %T; want *ast.BadType", typ)
+		}
+		assertBadLoc(t, bad.Err, bad.Loc, src, 0, 1)
+	})
+}
+
+func TestPartialEntryTrailingTokenSemantics(t *testing.T) {
+	failFast := parser.New()
+	recovery := parser.New(parser.WithRecovery())
+
+	cases := []struct {
+		name      string
+		body      string
+		failFast  func(*ast.Source) (ast.Node, error)
+		recovered func(*ast.Source) (ast.Node, error)
+		wantBad   string
+	}{
+		{
+			name: "document",
+			body: "query Get { field } !",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.Parse(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.Parse(src)
+			},
+			wantBad: "definition",
+		},
+		{
+			name: "schema",
+			body: "type Query { field: String } !",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.ParseSchema(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.ParseSchema(src)
+			},
+			wantBad: "definition",
+		},
+		{
+			name: "value",
+			body: "1 2",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.ParseValue(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.ParseValue(src)
+			},
+			wantBad: "value",
+		},
+		{
+			name: "const value",
+			body: "1 2",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.ParseConstValue(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.ParseConstValue(src)
+			},
+			wantBad: "value",
+		},
+		{
+			name: "type",
+			body: "Int String",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.ParseType(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.ParseType(src)
+			},
+			wantBad: "type",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &ast.Source{Body: tc.body, Name: tc.name + ".graphql"}
+			node, err := tc.failFast(src)
+			if err == nil {
+				t.Fatal("fail-fast parse returned nil error")
+			}
+			if tc.wantBad != "definition" && node != nil {
+				t.Fatalf("fail-fast node = %T; want nil", node)
+			}
+
+			src = &ast.Source{Body: tc.body, Name: tc.name + "-recovery.graphql"}
+			node, err = tc.recovered(src)
+			assertParseErrors(t, err, 1)
+			switch tc.wantBad {
+			case "definition":
+				doc, ok := node.(*ast.Document)
+				if !ok {
+					t.Fatalf("recovered node = %T; want *ast.Document", node)
+				}
+				if _, ok := doc.Definitions[len(doc.Definitions)-1].(*ast.BadDefinition); !ok {
+					t.Fatalf("last definition = %T; want *ast.BadDefinition", doc.Definitions[len(doc.Definitions)-1])
+				}
+			case "value":
+				if _, ok := node.(*ast.BadValue); !ok {
+					t.Fatalf("recovered node = %T; want *ast.BadValue", node)
+				}
+			case "type":
+				if _, ok := node.(*ast.BadType); !ok {
+					t.Fatalf("recovered node = %T; want *ast.BadType", node)
+				}
+			}
+		})
+	}
+}
+
+func TestEntryEOFRecoverySemantics(t *testing.T) {
+	failFast := parser.New()
+	recovery := parser.New(parser.WithRecovery())
+
+	cases := []struct {
+		name      string
+		failFast  func(*ast.Source) (ast.Node, error)
+		recovered func(*ast.Source) (ast.Node, error)
+		wantBad   string
+	}{
+		{
+			name: "document",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.Parse(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.Parse(src)
+			},
+		},
+		{
+			name: "schema",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.ParseSchema(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.ParseSchema(src)
+			},
+		},
+		{
+			name: "value",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.ParseValue(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.ParseValue(src)
+			},
+			wantBad: "value",
+		},
+		{
+			name: "const value",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.ParseConstValue(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.ParseConstValue(src)
+			},
+			wantBad: "value",
+		},
+		{
+			name: "type",
+			failFast: func(src *ast.Source) (ast.Node, error) {
+				return failFast.ParseType(src)
+			},
+			recovered: func(src *ast.Source) (ast.Node, error) {
+				return recovery.ParseType(src)
+			},
+			wantBad: "type",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &ast.Source{Name: tc.name + "-eof.graphql"}
+			node, err := tc.failFast(src)
+			if err == nil {
+				t.Fatal("fail-fast parse returned nil error")
+			}
+			if tc.wantBad != "" && node != nil {
+				t.Fatalf("fail-fast node = %T; want nil", node)
+			}
+
+			src = &ast.Source{Name: tc.name + "-eof-recovery.graphql"}
+			node, err = tc.recovered(src)
+			assertParseErrors(t, err, 1)
+			switch tc.wantBad {
+			case "":
+				// Document/schema entry points may return a typed nil document
+				// through the ast.Node test adapter; the ParseErrors assertion
+				// above is the compatibility contract being documented here.
+			case "value":
+				bad, ok := node.(*ast.BadValue)
+				if !ok {
+					t.Fatalf("recovered node = %T; want *ast.BadValue", node)
+				}
+				assertBadLoc(t, bad.Err, bad.Loc, src, 0, 0)
+			case "type":
+				bad, ok := node.(*ast.BadType)
+				if !ok {
+					t.Fatalf("recovered node = %T; want *ast.BadType", node)
+				}
+				assertBadLoc(t, bad.Err, bad.Loc, src, 0, 0)
+			}
+		})
+	}
+}
+
+func TestParserValueAndTypeRecoveryTreatsNestedFailureAsRootFailure(t *testing.T) {
+	p := parser.New(parser.WithRecovery())
+
+	t.Run("value", func(t *testing.T) {
+		src := &ast.Source{Body: "[1, !, 2]", Name: "nested-value.graphql"}
+		v, err := p.ParseValue(src)
+		assertParseErrors(t, err, 1)
+		bad, ok := v.(*ast.BadValue)
+		if !ok {
+			t.Fatalf("value = %T; want *ast.BadValue", v)
+		}
+		assertBadLoc(t, bad.Err, bad.Loc, src, 0, len(src.Body))
+	})
+
+	t.Run("type", func(t *testing.T) {
+		src := &ast.Source{Body: "[User!!]", Name: "nested-type.graphql"}
+		typ, err := p.ParseType(src)
+		assertParseErrors(t, err, 1)
+		bad, ok := typ.(*ast.BadType)
+		if !ok {
+			t.Fatalf("type = %T; want *ast.BadType", typ)
+		}
+		assertBadLoc(t, bad.Err, bad.Loc, src, 0, len(src.Body))
+	})
+}
+
+func assertLocSource(t *testing.T, loc *ast.Loc, src *ast.Source) {
+	t.Helper()
+	if loc == nil {
+		t.Fatal("Loc is nil")
+	}
+	if loc.Source != src {
+		t.Fatalf("Loc.Source = %p; want %p", loc.Source, src)
+	}
+}
+
+func assertParseErrors(t *testing.T, err error, wantLen int) parser.ParseErrors {
+	t.Helper()
+	if err == nil {
+		t.Fatal("parse returned nil error")
+	}
+	var errs parser.ParseErrors
+	if !errors.As(err, &errs) {
+		t.Fatalf("error = %T; want parser.ParseErrors", err)
+	}
+	if len(errs) != wantLen {
+		t.Fatalf("ParseErrors length = %d; want %d", len(errs), wantLen)
+	}
+	return errs
+}
+
+func assertBadLoc(t *testing.T, err *ast.SyntaxError, loc *ast.Loc, src *ast.Source, wantStart, wantEnd int) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("bad node Err is nil")
+	}
+	if err.Source != src {
+		t.Fatalf("bad node Err.Source = %p; want %p", err.Source, src)
+	}
+	assertLocSource(t, loc, src)
+	if loc.Start != wantStart || loc.End != wantEnd {
+		t.Fatalf("bad node Loc = [%d, %d); want [%d, %d)", loc.Start, loc.End, wantStart, wantEnd)
+	}
+}

--- a/parser/options.go
+++ b/parser/options.go
@@ -10,11 +10,13 @@ type config struct {
 	preserveComments bool
 }
 
-// WithRecovery enables error recovery: the parser collects multiple syntax
-// errors instead of aborting on the first, inserting Bad{Definition, Field,
-// Value, Type} placeholder nodes where it had to resynchronize. The returned
-// error is a [ParseErrors] aggregating every error found; the [ast.Document]
-// is still populated with whatever was parsed successfully.
+// WithRecovery enables error recovery: the parser collects syntax errors
+// instead of aborting on the first one, inserting Bad{Definition, Field, Value,
+// Type} placeholder nodes where it had to resynchronize. Document parsing can
+// return a partial [ast.Document]. Value and type entry points recover only at
+// the root entry: a malformed value/type input returns one BadValue or BadType
+// for the whole partial input rather than nested placeholders. The returned
+// error is a [ParseErrors] aggregating every error found.
 //
 // When this option is not set, the parser fails fast on the first syntax
 // error and the conformance corpus runs in this default mode.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -29,13 +29,16 @@ type prodScope struct {
 }
 
 func newParser(src *ast.Source, opts []Option) *parser {
-	cfg := newConfig(opts)
+	return newParserWithConfig(src, *newConfig(opts))
+}
+
+func newParserWithConfig(src *ast.Source, cfg config) *parser {
 	var lopts []lexer.Option
 	if cfg.preserveComments {
 		lopts = append(lopts, lexer.WithComments())
 	}
 	l := lexer.New(src, lopts...)
-	return &parser{source: src, lex: l, cfg: cfg}
+	return &parser{source: src, lex: l, cfg: &cfg}
 }
 
 // peek returns the next non-comment token without consuming it. When

--- a/parser/recover.go
+++ b/parser/recover.go
@@ -97,3 +97,28 @@ func (p *parser) skipToSelectionStart() {
 		}
 	}
 }
+
+// skipToEOF advances to the end of a partial entry point after a root-level
+// value/type failure. It intentionally does not try to recover nested grammar.
+func (p *parser) skipToEOF() {
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			if !p.recordError(err) {
+				return
+			}
+			if _, err2 := p.advance(); err2 != nil {
+				_ = p.recordError(err2)
+				return
+			}
+			continue
+		}
+		if tok.Kind == lexer.EOF {
+			return
+		}
+		if _, err := p.advance(); err != nil {
+			_ = p.recordError(err)
+			return
+		}
+	}
+}

--- a/parser/recover.go
+++ b/parser/recover.go
@@ -106,11 +106,11 @@ func (p *parser) skipToEOF() {
 		if err != nil {
 			// The caller already recorded the root failure that put the
 			// partial entry into recovery. Clear a cached lexer error without
-			// recording the same error again, then treat the rest of the entry
-			// as covered by the root BadValue/BadType placeholder.
+			// recording the same error again, then continue draining any
+			// remaining tokens as covered by the root recovery placeholder.
 			_, _ = p.advance()
 			p.lastEnd = len(p.source.Body)
-			return
+			continue
 		}
 		if tok.Kind == lexer.EOF {
 			return

--- a/parser/recover.go
+++ b/parser/recover.go
@@ -104,14 +104,13 @@ func (p *parser) skipToEOF() {
 	for {
 		tok, err := p.peek()
 		if err != nil {
-			if !p.recordError(err) {
-				return
-			}
-			if _, err2 := p.advance(); err2 != nil {
-				_ = p.recordError(err2)
-				return
-			}
-			continue
+			// The caller already recorded the root failure that put the
+			// partial entry into recovery. Clear a cached lexer error without
+			// recording the same error again, then treat the rest of the entry
+			// as covered by the root BadValue/BadType placeholder.
+			_, _ = p.advance()
+			p.lastEnd = len(p.source.Body)
+			return
 		}
 		if tok.Kind == lexer.EOF {
 			return


### PR DESCRIPTION
## Summary

Adds reusable parser instance entry points for documents, schema documents, values, const values, and types while preserving the existing package-level API.

Closes #5.

## Implementation

- Introduces exported `parser.Parser` methods plus source-aware parsing helpers.
- Keeps package-level `Parse*` functions as compatibility shims over the reusable parser API.
- Wires root-level value/type recovery through the existing parse error plumbing.
- Adds coverage for parser instance reuse, source offsets, EOF handling, schema rejection behavior, and lexer-error recovery.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `gofmt -l .`
- hot-path grep checks for disallowed `regexp`, `reflect`, and `fmt.Sprintf` usage