### PR TITLE
Refactor AST traversal to child dispatch

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,9 +2,11 @@ package ast
 
 // Node is the super-interface satisfied by every AST node. The location is
 // nullable: synthetic nodes constructed by tools (codegen, transforms) may
-// have a nil Loc.
+// have a nil Loc. Children returns the node's AST children in source order,
+// excluding nil children and comments.
 type Node interface {
 	GetLoc() *Loc
+	Children() []Node
 }
 
 // Definition is the union of all top-level definitions in a Document:

--- a/ast/bad.go
+++ b/ast/bad.go
@@ -8,8 +8,9 @@ type BadValue struct {
 	Loc *Loc
 }
 
-func (v *BadValue) GetLoc() *Loc { return v.Loc }
-func (*BadValue) isValue()       {}
+func (v *BadValue) GetLoc() *Loc   { return v.Loc }
+func (*BadValue) Children() []Node { return nil }
+func (*BadValue) isValue()         {}
 
 // BadType is a placeholder Type for recovery.
 type BadType struct {
@@ -17,8 +18,9 @@ type BadType struct {
 	Loc *Loc
 }
 
-func (t *BadType) GetLoc() *Loc { return t.Loc }
-func (*BadType) isType()        {}
+func (t *BadType) GetLoc() *Loc   { return t.Loc }
+func (*BadType) Children() []Node { return nil }
+func (*BadType) isType()          {}
 
 // BadField is a placeholder Selection for recovery — used when a selection
 // inside a SelectionSet failed to parse.
@@ -27,8 +29,9 @@ type BadField struct {
 	Loc *Loc
 }
 
-func (f *BadField) GetLoc() *Loc { return f.Loc }
-func (*BadField) isSelection()   {}
+func (f *BadField) GetLoc() *Loc   { return f.Loc }
+func (*BadField) Children() []Node { return nil }
+func (*BadField) isSelection()     {}
 
 // BadDefinition is a placeholder top-level Definition for recovery.
 type BadDefinition struct {
@@ -36,5 +39,6 @@ type BadDefinition struct {
 	Loc *Loc
 }
 
-func (d *BadDefinition) GetLoc() *Loc { return d.Loc }
-func (*BadDefinition) isDefinition()  {}
+func (d *BadDefinition) GetLoc() *Loc   { return d.Loc }
+func (*BadDefinition) Children() []Node { return nil }
+func (*BadDefinition) isDefinition()    {}

--- a/ast/benchmark_test.go
+++ b/ast/benchmark_test.go
@@ -1,0 +1,96 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/brian-bell/graphql-parser/ast"
+	"github.com/brian-bell/graphql-parser/parser"
+)
+
+const walkExecutable = `
+query GetUser($id: ID!, $includeFriends: Boolean = true) @trace {
+	user(id: $id) {
+		id
+		name
+		friends @include(if: $includeFriends) {
+			nodes { id name }
+		}
+		...UserFields
+		... on Admin { permissions }
+	}
+}
+
+fragment UserFields on User {
+	email
+	profile { avatar }
+}
+`
+
+const walkSchema = `
+"""User account."""
+type User implements Node @auth {
+	"""Stable id."""
+	id: ID!
+	name(format: NameFormat = LONG): String!
+	friends(first: Int, after: String): UserConnection!
+}
+
+interface Node { id: ID! }
+union SearchResult = User | Organization
+enum NameFormat { SHORT LONG }
+input UserFilter { q: String active: Boolean = true }
+scalar DateTime
+directive @auth(role: Role = ADMIN) repeatable on FIELD_DEFINITION | OBJECT
+schema { query: Query }
+extend type User { createdAt: DateTime }
+`
+
+type countVisitor int
+
+func (c *countVisitor) Visit(ast.Node) ast.Visitor {
+	*c++
+	return c
+}
+
+func benchmarkWalk(b *testing.B, node ast.Node) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var count countVisitor
+		ast.Walk(&count, node)
+		if count == 0 {
+			b.Fatal("walk visited no nodes")
+		}
+	}
+}
+
+func BenchmarkWalkExecutable(b *testing.B) {
+	doc, err := parser.Parse(walkExecutable)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkWalk(b, doc)
+}
+
+func BenchmarkWalkSchema(b *testing.B) {
+	doc, err := parser.Parse(walkSchema)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkWalk(b, doc)
+}
+
+func BenchmarkWalkValue(b *testing.B) {
+	value, err := parser.ParseValue(`{a: [1, "hi", $v, ENUM, true, null], b: {nested: 1}}`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkWalk(b, value)
+}
+
+func BenchmarkWalkType(b *testing.B) {
+	typ, err := parser.ParseType("[[Int!]!]!")
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkWalk(b, typ)
+}

--- a/ast/children_test.go
+++ b/ast/children_test.go
@@ -155,9 +155,15 @@ func TestChildren_OrderForNonLeafNodes(t *testing.T) {
 		SelectionSet:  selectionSet,
 	}
 	objectField := &ast.ObjectField{Name: "field", Value: defaultValue}
+	fieldArg := &ast.InputValueDefinition{
+		Description:  desc,
+		Type:         named,
+		DefaultValue: defaultValue,
+		Directives:   ast.DirectiveList{dir},
+	}
 	fieldDefinition := &ast.FieldDefinition{
 		Description: desc,
-		Arguments:   ast.InputValueList{},
+		Arguments:   ast.InputValueList{fieldArg},
 		Type:        named,
 		Directives:  ast.DirectiveList{dir},
 	}
@@ -328,7 +334,7 @@ func TestChildren_OrderForNonLeafNodes(t *testing.T) {
 		{
 			name: "FieldDefinition",
 			node: fieldDefinition,
-			want: []ast.Node{desc, named, dir},
+			want: []ast.Node{desc, fieldArg, named, dir},
 		},
 		{
 			name: "InputValueDefinition",

--- a/ast/children_test.go
+++ b/ast/children_test.go
@@ -1,0 +1,399 @@
+package ast_test
+
+import (
+	goast "go/ast"
+	goparser "go/parser"
+	"go/token"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/brian-bell/graphql-parser/ast"
+)
+
+var concreteNodes = []ast.Node{
+	(*ast.Document)(nil),
+	(*ast.OperationDefinition)(nil),
+	(*ast.FragmentDefinition)(nil),
+	(*ast.VariableDefinition)(nil),
+	(*ast.SelectionSet)(nil),
+	(*ast.Field)(nil),
+	(*ast.FragmentSpread)(nil),
+	(*ast.InlineFragment)(nil),
+	(*ast.Argument)(nil),
+	(*ast.Directive)(nil),
+	(*ast.SchemaDefinition)(nil),
+	(*ast.SchemaExtension)(nil),
+	(*ast.OperationTypeDefinition)(nil),
+	(*ast.ScalarTypeDefinition)(nil),
+	(*ast.ScalarTypeExtension)(nil),
+	(*ast.ObjectTypeDefinition)(nil),
+	(*ast.ObjectTypeExtension)(nil),
+	(*ast.InterfaceTypeDefinition)(nil),
+	(*ast.InterfaceTypeExtension)(nil),
+	(*ast.UnionTypeDefinition)(nil),
+	(*ast.UnionTypeExtension)(nil),
+	(*ast.EnumTypeDefinition)(nil),
+	(*ast.EnumTypeExtension)(nil),
+	(*ast.InputObjectTypeDefinition)(nil),
+	(*ast.InputObjectTypeExtension)(nil),
+	(*ast.FieldDefinition)(nil),
+	(*ast.InputValueDefinition)(nil),
+	(*ast.EnumValueDefinition)(nil),
+	(*ast.DirectiveDefinition)(nil),
+	(*ast.IntValue)(nil),
+	(*ast.FloatValue)(nil),
+	(*ast.StringValue)(nil),
+	(*ast.BooleanValue)(nil),
+	(*ast.NullValue)(nil),
+	(*ast.EnumValue)(nil),
+	(*ast.ListValue)(nil),
+	(*ast.ObjectValue)(nil),
+	(*ast.ObjectField)(nil),
+	(*ast.Variable)(nil),
+	(*ast.NamedType)(nil),
+	(*ast.ListType)(nil),
+	(*ast.NonNullType)(nil),
+	(*ast.BadValue)(nil),
+	(*ast.BadType)(nil),
+	(*ast.BadField)(nil),
+	(*ast.BadDefinition)(nil),
+	(*ast.Comment)(nil),
+}
+
+const concreteNodeCount = 47
+
+func TestNode_RegistryExhaustive(t *testing.T) {
+	expected := structsWithGetLocMethod(t)
+
+	actual := map[string]bool{}
+	for _, n := range concreteNodes {
+		actual[reflect.TypeOf(n).Elem().Name()] = true
+	}
+
+	if len(expected) != concreteNodeCount {
+		t.Fatalf("source declares %d node structs; want %d (got %s)",
+			len(expected), concreteNodeCount, sortedKeys(expected))
+	}
+	if len(concreteNodes) != concreteNodeCount {
+		t.Fatalf("concreteNodes registry has %d entries; want %d", len(concreteNodes), concreteNodeCount)
+	}
+
+	for name := range expected {
+		if !actual[name] {
+			t.Errorf("%s has GetLoc but is missing from concreteNodes", name)
+		}
+	}
+	for name := range actual {
+		if !expected[name] {
+			t.Errorf("%s is registered in concreteNodes but has no GetLoc method", name)
+		}
+	}
+}
+
+func structsWithGetLocMethod(t *testing.T) map[string]bool {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(astDir(t), "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	found := map[string]bool{}
+	fset := token.NewFileSet()
+	for _, path := range matches {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := goparser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		goast.Inspect(file, func(n goast.Node) bool {
+			decl, ok := n.(*goast.FuncDecl)
+			if !ok || decl.Name.Name != "GetLoc" || decl.Recv == nil || len(decl.Recv.List) != 1 {
+				return true
+			}
+			star, ok := decl.Recv.List[0].Type.(*goast.StarExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := star.X.(*goast.Ident)
+			if ok {
+				found[ident.Name] = true
+			}
+			return true
+		})
+	}
+	return found
+}
+
+func TestChildren_OrderForNonLeafNodes(t *testing.T) {
+	desc := &ast.StringValue{Value: "desc"}
+	variable := &ast.Variable{Name: "v"}
+	named := &ast.NamedType{Name: "T"}
+	defaultValue := &ast.IntValue{Value: "1"}
+	arg := &ast.Argument{Name: "arg", Value: defaultValue}
+	dir := &ast.Directive{Name: "dir", Arguments: ast.ArgumentList{arg}}
+	selectionSet := &ast.SelectionSet{}
+	field := &ast.Field{Name: "field"}
+	fragmentSpread := &ast.FragmentSpread{Name: "frag"}
+	inlineFragment := &ast.InlineFragment{}
+	variableDefinition := &ast.VariableDefinition{
+		Variable:     variable,
+		Type:         named,
+		DefaultValue: defaultValue,
+		Directives:   ast.DirectiveList{dir},
+	}
+	operationDefinition := &ast.OperationDefinition{
+		VariableDefinitions: ast.VariableDefinitionList{variableDefinition},
+		Directives:          ast.DirectiveList{dir},
+		SelectionSet:        selectionSet,
+	}
+	fragmentDefinition := &ast.FragmentDefinition{
+		TypeCondition: named,
+		Directives:    ast.DirectiveList{dir},
+		SelectionSet:  selectionSet,
+	}
+	objectField := &ast.ObjectField{Name: "field", Value: defaultValue}
+	fieldDefinition := &ast.FieldDefinition{
+		Description: desc,
+		Arguments:   ast.InputValueList{},
+		Type:        named,
+		Directives:  ast.DirectiveList{dir},
+	}
+	inputValue := &ast.InputValueDefinition{
+		Description:  desc,
+		Type:         named,
+		DefaultValue: defaultValue,
+		Directives:   ast.DirectiveList{dir},
+	}
+	enumValue := &ast.EnumValueDefinition{Description: desc, Directives: ast.DirectiveList{dir}}
+	operationType := &ast.OperationTypeDefinition{Type: named}
+
+	tests := []struct {
+		name string
+		node ast.Node
+		want []ast.Node
+	}{
+		{
+			name: "Document",
+			node: &ast.Document{Definitions: ast.DefinitionList{operationDefinition, fragmentDefinition}},
+			want: []ast.Node{operationDefinition, fragmentDefinition},
+		},
+		{
+			name: "OperationDefinition",
+			node: operationDefinition,
+			want: []ast.Node{variableDefinition, dir, selectionSet},
+		},
+		{
+			name: "FragmentDefinition",
+			node: fragmentDefinition,
+			want: []ast.Node{named, dir, selectionSet},
+		},
+		{
+			name: "VariableDefinition",
+			node: variableDefinition,
+			want: []ast.Node{variable, named, defaultValue, dir},
+		},
+		{
+			name: "SelectionSet",
+			node: &ast.SelectionSet{Selections: []ast.Selection{field, fragmentSpread, inlineFragment}},
+			want: []ast.Node{field, fragmentSpread, inlineFragment},
+		},
+		{
+			name: "Field",
+			node: &ast.Field{Arguments: ast.ArgumentList{arg}, Directives: ast.DirectiveList{dir}, SelectionSet: selectionSet},
+			want: []ast.Node{arg, dir, selectionSet},
+		},
+		{
+			name: "FragmentSpread",
+			node: &ast.FragmentSpread{Directives: ast.DirectiveList{dir}},
+			want: []ast.Node{dir},
+		},
+		{
+			name: "InlineFragment",
+			node: &ast.InlineFragment{TypeCondition: named, Directives: ast.DirectiveList{dir}, SelectionSet: selectionSet},
+			want: []ast.Node{named, dir, selectionSet},
+		},
+		{
+			name: "Argument",
+			node: arg,
+			want: []ast.Node{defaultValue},
+		},
+		{
+			name: "Directive",
+			node: dir,
+			want: []ast.Node{arg},
+		},
+		{
+			name: "ListValue",
+			node: &ast.ListValue{Values: []ast.Value{defaultValue, desc}},
+			want: []ast.Node{defaultValue, desc},
+		},
+		{
+			name: "ObjectValue",
+			node: &ast.ObjectValue{Fields: []*ast.ObjectField{objectField}},
+			want: []ast.Node{objectField},
+		},
+		{
+			name: "ObjectField",
+			node: objectField,
+			want: []ast.Node{defaultValue},
+		},
+		{
+			name: "ListType",
+			node: &ast.ListType{OfType: named},
+			want: []ast.Node{named},
+		},
+		{
+			name: "NonNullType",
+			node: &ast.NonNullType{OfType: named},
+			want: []ast.Node{named},
+		},
+		{
+			name: "SchemaDefinition",
+			node: &ast.SchemaDefinition{Description: desc, Directives: ast.DirectiveList{dir}, OperationTypes: []*ast.OperationTypeDefinition{operationType}},
+			want: []ast.Node{desc, dir, operationType},
+		},
+		{
+			name: "SchemaExtension",
+			node: &ast.SchemaExtension{Directives: ast.DirectiveList{dir}, OperationTypes: []*ast.OperationTypeDefinition{operationType}},
+			want: []ast.Node{dir, operationType},
+		},
+		{
+			name: "OperationTypeDefinition",
+			node: operationType,
+			want: []ast.Node{named},
+		},
+		{
+			name: "ScalarTypeDefinition",
+			node: &ast.ScalarTypeDefinition{Description: desc, Directives: ast.DirectiveList{dir}},
+			want: []ast.Node{desc, dir},
+		},
+		{
+			name: "ScalarTypeExtension",
+			node: &ast.ScalarTypeExtension{Directives: ast.DirectiveList{dir}},
+			want: []ast.Node{dir},
+		},
+		{
+			name: "ObjectTypeDefinition",
+			node: &ast.ObjectTypeDefinition{Description: desc, Interfaces: []*ast.NamedType{named}, Directives: ast.DirectiveList{dir}, Fields: ast.FieldDefinitionList{fieldDefinition}},
+			want: []ast.Node{desc, named, dir, fieldDefinition},
+		},
+		{
+			name: "ObjectTypeExtension",
+			node: &ast.ObjectTypeExtension{Interfaces: []*ast.NamedType{named}, Directives: ast.DirectiveList{dir}, Fields: ast.FieldDefinitionList{fieldDefinition}},
+			want: []ast.Node{named, dir, fieldDefinition},
+		},
+		{
+			name: "InterfaceTypeDefinition",
+			node: &ast.InterfaceTypeDefinition{Description: desc, Interfaces: []*ast.NamedType{named}, Directives: ast.DirectiveList{dir}, Fields: ast.FieldDefinitionList{fieldDefinition}},
+			want: []ast.Node{desc, named, dir, fieldDefinition},
+		},
+		{
+			name: "InterfaceTypeExtension",
+			node: &ast.InterfaceTypeExtension{Interfaces: []*ast.NamedType{named}, Directives: ast.DirectiveList{dir}, Fields: ast.FieldDefinitionList{fieldDefinition}},
+			want: []ast.Node{named, dir, fieldDefinition},
+		},
+		{
+			name: "UnionTypeDefinition",
+			node: &ast.UnionTypeDefinition{Description: desc, Directives: ast.DirectiveList{dir}, Members: []*ast.NamedType{named}},
+			want: []ast.Node{desc, dir, named},
+		},
+		{
+			name: "UnionTypeExtension",
+			node: &ast.UnionTypeExtension{Directives: ast.DirectiveList{dir}, Members: []*ast.NamedType{named}},
+			want: []ast.Node{dir, named},
+		},
+		{
+			name: "EnumTypeDefinition",
+			node: &ast.EnumTypeDefinition{Description: desc, Directives: ast.DirectiveList{dir}, Values: ast.EnumValueList{enumValue}},
+			want: []ast.Node{desc, dir, enumValue},
+		},
+		{
+			name: "EnumTypeExtension",
+			node: &ast.EnumTypeExtension{Directives: ast.DirectiveList{dir}, Values: ast.EnumValueList{enumValue}},
+			want: []ast.Node{dir, enumValue},
+		},
+		{
+			name: "InputObjectTypeDefinition",
+			node: &ast.InputObjectTypeDefinition{Description: desc, Directives: ast.DirectiveList{dir}, Fields: ast.InputValueList{inputValue}},
+			want: []ast.Node{desc, dir, inputValue},
+		},
+		{
+			name: "InputObjectTypeExtension",
+			node: &ast.InputObjectTypeExtension{Directives: ast.DirectiveList{dir}, Fields: ast.InputValueList{inputValue}},
+			want: []ast.Node{dir, inputValue},
+		},
+		{
+			name: "FieldDefinition",
+			node: fieldDefinition,
+			want: []ast.Node{desc, named, dir},
+		},
+		{
+			name: "InputValueDefinition",
+			node: inputValue,
+			want: []ast.Node{desc, named, defaultValue, dir},
+		},
+		{
+			name: "EnumValueDefinition",
+			node: enumValue,
+			want: []ast.Node{desc, dir},
+		},
+		{
+			name: "DirectiveDefinition",
+			node: &ast.DirectiveDefinition{Description: desc, Arguments: ast.InputValueList{inputValue}, Locations: []string{"FIELD"}},
+			want: []ast.Node{desc, inputValue},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertChildren(t, tt.node, tt.want...)
+		})
+	}
+}
+
+func TestChildren_SkipsNilChildren(t *testing.T) {
+	value := &ast.IntValue{Value: "1"}
+	node := &ast.ListValue{Values: []ast.Value{nil, value, nil}}
+	assertChildren(t, node, value)
+}
+
+func TestChildren_LeavesReturnNil(t *testing.T) {
+	leaves := []ast.Node{
+		&ast.IntValue{},
+		&ast.FloatValue{},
+		&ast.StringValue{},
+		&ast.BooleanValue{},
+		&ast.NullValue{},
+		&ast.EnumValue{},
+		&ast.Variable{},
+		&ast.NamedType{},
+		&ast.Comment{},
+		&ast.BadValue{},
+		&ast.BadType{},
+		&ast.BadField{},
+		&ast.BadDefinition{},
+	}
+
+	for _, node := range leaves {
+		if children := node.Children(); len(children) != 0 {
+			t.Errorf("%T.Children() = %v; want no children", node, children)
+		}
+	}
+}
+
+func assertChildren(t *testing.T, node ast.Node, want ...ast.Node) {
+	t.Helper()
+	got := node.Children()
+	if len(got) != len(want) {
+		t.Fatalf("%T.Children() length = %d; want %d (%#v)", node, len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%T.Children()[%d] = %T(%p); want %T(%p)",
+				node, i, got[i], got[i], want[i], want[i])
+		}
+	}
+}

--- a/ast/comment.go
+++ b/ast/comment.go
@@ -10,6 +10,9 @@ type Comment struct {
 // GetLoc returns the comment's location.
 func (c *Comment) GetLoc() *Loc { return c.Loc }
 
+// Children returns nil because comments are traversal leaves.
+func (*Comment) Children() []Node { return nil }
+
 // CommentGroup attaches a node's leading and trailing comments. It is set on
 // AST nodes only when the parser is run with the WithComments option;
 // otherwise the field on each node is nil.

--- a/ast/document.go
+++ b/ast/document.go
@@ -14,6 +14,17 @@ type Document struct {
 // GetLoc returns the document's location.
 func (d *Document) GetLoc() *Loc { return d.Loc }
 
+// Children returns the document definitions in source order.
+func (d *Document) Children() []Node {
+	children := make([]Node, 0, len(d.Definitions))
+	for _, def := range d.Definitions {
+		if def != nil {
+			children = append(children, def)
+		}
+	}
+	return children
+}
+
 // CommentSlot returns a pointer to the document's Comments field.
 func (d *Document) CommentSlot() **CommentGroup { return &d.Comments }
 

--- a/ast/executable.go
+++ b/ast/executable.go
@@ -25,7 +25,24 @@ type OperationDefinition struct {
 	Comments            *CommentGroup
 }
 
-func (d *OperationDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *OperationDefinition) GetLoc() *Loc { return d.Loc }
+func (d *OperationDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.VariableDefinitions)+len(d.Directives)+1)
+	for _, vd := range d.VariableDefinitions {
+		if vd != nil {
+			children = append(children, vd)
+		}
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	if d.SelectionSet != nil {
+		children = append(children, d.SelectionSet)
+	}
+	return children
+}
 func (*OperationDefinition) isDefinition()                 {}
 func (d *OperationDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -39,7 +56,22 @@ type FragmentDefinition struct {
 	Comments      *CommentGroup
 }
 
-func (d *FragmentDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *FragmentDefinition) GetLoc() *Loc { return d.Loc }
+func (d *FragmentDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+2)
+	if d.TypeCondition != nil {
+		children = append(children, d.TypeCondition)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	if d.SelectionSet != nil {
+		children = append(children, d.SelectionSet)
+	}
+	return children
+}
 func (*FragmentDefinition) isDefinition()                 {}
 func (d *FragmentDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -54,7 +86,25 @@ type VariableDefinition struct {
 	Comments     *CommentGroup
 }
 
-func (v *VariableDefinition) GetLoc() *Loc                { return v.Loc }
+func (v *VariableDefinition) GetLoc() *Loc { return v.Loc }
+func (v *VariableDefinition) Children() []Node {
+	children := make([]Node, 0, len(v.Directives)+3)
+	if v.Variable != nil {
+		children = append(children, v.Variable)
+	}
+	if v.Type != nil {
+		children = append(children, v.Type)
+	}
+	if v.DefaultValue != nil {
+		children = append(children, v.DefaultValue)
+	}
+	for _, dir := range v.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	return children
+}
 func (v *VariableDefinition) CommentSlot() **CommentGroup { return &v.Comments }
 
 // SelectionSet is a "{ ... }" block of one or more Selections.
@@ -65,7 +115,16 @@ type SelectionSet struct {
 }
 
 // GetLoc returns the location covering the selection set including its braces.
-func (s *SelectionSet) GetLoc() *Loc                { return s.Loc }
+func (s *SelectionSet) GetLoc() *Loc { return s.Loc }
+func (s *SelectionSet) Children() []Node {
+	children := make([]Node, 0, len(s.Selections))
+	for _, sel := range s.Selections {
+		if sel != nil {
+			children = append(children, sel)
+		}
+	}
+	return children
+}
 func (s *SelectionSet) CommentSlot() **CommentGroup { return &s.Comments }
 
 // Field is a leaf or non-leaf selection: "[alias:] name(args)? @dir...?
@@ -80,7 +139,24 @@ type Field struct {
 	Comments     *CommentGroup
 }
 
-func (f *Field) GetLoc() *Loc                { return f.Loc }
+func (f *Field) GetLoc() *Loc { return f.Loc }
+func (f *Field) Children() []Node {
+	children := make([]Node, 0, len(f.Arguments)+len(f.Directives)+1)
+	for _, arg := range f.Arguments {
+		if arg != nil {
+			children = append(children, arg)
+		}
+	}
+	for _, dir := range f.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	if f.SelectionSet != nil {
+		children = append(children, f.SelectionSet)
+	}
+	return children
+}
 func (*Field) isSelection()                  {}
 func (f *Field) CommentSlot() **CommentGroup { return &f.Comments }
 
@@ -93,7 +169,16 @@ type FragmentSpread struct {
 	Comments   *CommentGroup
 }
 
-func (s *FragmentSpread) GetLoc() *Loc                { return s.Loc }
+func (s *FragmentSpread) GetLoc() *Loc { return s.Loc }
+func (s *FragmentSpread) Children() []Node {
+	children := make([]Node, 0, len(s.Directives))
+	for _, dir := range s.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	return children
+}
 func (*FragmentSpread) isSelection()                  {}
 func (s *FragmentSpread) CommentSlot() **CommentGroup { return &s.Comments }
 
@@ -108,7 +193,22 @@ type InlineFragment struct {
 	Comments      *CommentGroup
 }
 
-func (f *InlineFragment) GetLoc() *Loc                { return f.Loc }
+func (f *InlineFragment) GetLoc() *Loc { return f.Loc }
+func (f *InlineFragment) Children() []Node {
+	children := make([]Node, 0, len(f.Directives)+2)
+	if f.TypeCondition != nil {
+		children = append(children, f.TypeCondition)
+	}
+	for _, dir := range f.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	if f.SelectionSet != nil {
+		children = append(children, f.SelectionSet)
+	}
+	return children
+}
 func (*InlineFragment) isSelection()                  {}
 func (f *InlineFragment) CommentSlot() **CommentGroup { return &f.Comments }
 
@@ -120,7 +220,13 @@ type Argument struct {
 	Comments *CommentGroup
 }
 
-func (a *Argument) GetLoc() *Loc                { return a.Loc }
+func (a *Argument) GetLoc() *Loc { return a.Loc }
+func (a *Argument) Children() []Node {
+	if a.Value == nil {
+		return nil
+	}
+	return []Node{a.Value}
+}
 func (a *Argument) CommentSlot() **CommentGroup { return &a.Comments }
 
 // Directive is "@name(args)?". Arguments must be const values when the
@@ -133,5 +239,14 @@ type Directive struct {
 	Comments  *CommentGroup
 }
 
-func (d *Directive) GetLoc() *Loc                { return d.Loc }
+func (d *Directive) GetLoc() *Loc { return d.Loc }
+func (d *Directive) Children() []Node {
+	children := make([]Node, 0, len(d.Arguments))
+	for _, arg := range d.Arguments {
+		if arg != nil {
+			children = append(children, arg)
+		}
+	}
+	return children
+}
 func (d *Directive) CommentSlot() **CommentGroup { return &d.Comments }

--- a/ast/schema.go
+++ b/ast/schema.go
@@ -9,7 +9,24 @@ type SchemaDefinition struct {
 	Comments       *CommentGroup
 }
 
-func (d *SchemaDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *SchemaDefinition) GetLoc() *Loc { return d.Loc }
+func (d *SchemaDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+len(d.OperationTypes)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, op := range d.OperationTypes {
+		if op != nil {
+			children = append(children, op)
+		}
+	}
+	return children
+}
 func (*SchemaDefinition) isDefinition()                 {}
 func (d *SchemaDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -22,7 +39,21 @@ type SchemaExtension struct {
 	Comments       *CommentGroup
 }
 
-func (d *SchemaExtension) GetLoc() *Loc                { return d.Loc }
+func (d *SchemaExtension) GetLoc() *Loc { return d.Loc }
+func (d *SchemaExtension) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+len(d.OperationTypes))
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, op := range d.OperationTypes {
+		if op != nil {
+			children = append(children, op)
+		}
+	}
+	return children
+}
 func (*SchemaExtension) isDefinition()                 {}
 func (d *SchemaExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -34,7 +65,13 @@ type OperationTypeDefinition struct {
 	Comments  *CommentGroup
 }
 
-func (d *OperationTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *OperationTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (d *OperationTypeDefinition) Children() []Node {
+	if d.Type == nil {
+		return nil
+	}
+	return []Node{d.Type}
+}
 func (d *OperationTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // ScalarTypeDefinition declares a custom scalar type.
@@ -46,7 +83,19 @@ type ScalarTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *ScalarTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *ScalarTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (d *ScalarTypeDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	return children
+}
 func (*ScalarTypeDefinition) isDefinition()                 {}
 func (d *ScalarTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -58,7 +107,16 @@ type ScalarTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *ScalarTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (d *ScalarTypeExtension) GetLoc() *Loc { return d.Loc }
+func (d *ScalarTypeExtension) Children() []Node {
+	children := make([]Node, 0, len(d.Directives))
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	return children
+}
 func (*ScalarTypeExtension) isDefinition()                 {}
 func (d *ScalarTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -73,7 +131,29 @@ type ObjectTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *ObjectTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *ObjectTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (d *ObjectTypeDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Interfaces)+len(d.Directives)+len(d.Fields)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, iface := range d.Interfaces {
+		if iface != nil {
+			children = append(children, iface)
+		}
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, field := range d.Fields {
+		if field != nil {
+			children = append(children, field)
+		}
+	}
+	return children
+}
 func (*ObjectTypeDefinition) isDefinition()                 {}
 func (d *ObjectTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -87,7 +167,26 @@ type ObjectTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *ObjectTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (d *ObjectTypeExtension) GetLoc() *Loc { return d.Loc }
+func (d *ObjectTypeExtension) Children() []Node {
+	children := make([]Node, 0, len(d.Interfaces)+len(d.Directives)+len(d.Fields))
+	for _, iface := range d.Interfaces {
+		if iface != nil {
+			children = append(children, iface)
+		}
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, field := range d.Fields {
+		if field != nil {
+			children = append(children, field)
+		}
+	}
+	return children
+}
 func (*ObjectTypeExtension) isDefinition()                 {}
 func (d *ObjectTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -102,7 +201,29 @@ type InterfaceTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *InterfaceTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *InterfaceTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (d *InterfaceTypeDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Interfaces)+len(d.Directives)+len(d.Fields)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, iface := range d.Interfaces {
+		if iface != nil {
+			children = append(children, iface)
+		}
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, field := range d.Fields {
+		if field != nil {
+			children = append(children, field)
+		}
+	}
+	return children
+}
 func (*InterfaceTypeDefinition) isDefinition()                 {}
 func (d *InterfaceTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -116,7 +237,26 @@ type InterfaceTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *InterfaceTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (d *InterfaceTypeExtension) GetLoc() *Loc { return d.Loc }
+func (d *InterfaceTypeExtension) Children() []Node {
+	children := make([]Node, 0, len(d.Interfaces)+len(d.Directives)+len(d.Fields))
+	for _, iface := range d.Interfaces {
+		if iface != nil {
+			children = append(children, iface)
+		}
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, field := range d.Fields {
+		if field != nil {
+			children = append(children, field)
+		}
+	}
+	return children
+}
 func (*InterfaceTypeExtension) isDefinition()                 {}
 func (d *InterfaceTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -130,7 +270,24 @@ type UnionTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *UnionTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *UnionTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (d *UnionTypeDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+len(d.Members)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, member := range d.Members {
+		if member != nil {
+			children = append(children, member)
+		}
+	}
+	return children
+}
 func (*UnionTypeDefinition) isDefinition()                 {}
 func (d *UnionTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -143,7 +300,21 @@ type UnionTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *UnionTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (d *UnionTypeExtension) GetLoc() *Loc { return d.Loc }
+func (d *UnionTypeExtension) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+len(d.Members))
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, member := range d.Members {
+		if member != nil {
+			children = append(children, member)
+		}
+	}
+	return children
+}
 func (*UnionTypeExtension) isDefinition()                 {}
 func (d *UnionTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -157,7 +328,24 @@ type EnumTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *EnumTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *EnumTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (d *EnumTypeDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+len(d.Values)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, value := range d.Values {
+		if value != nil {
+			children = append(children, value)
+		}
+	}
+	return children
+}
 func (*EnumTypeDefinition) isDefinition()                 {}
 func (d *EnumTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -170,7 +358,21 @@ type EnumTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *EnumTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (d *EnumTypeExtension) GetLoc() *Loc { return d.Loc }
+func (d *EnumTypeExtension) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+len(d.Values))
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, value := range d.Values {
+		if value != nil {
+			children = append(children, value)
+		}
+	}
+	return children
+}
 func (*EnumTypeExtension) isDefinition()                 {}
 func (d *EnumTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -184,7 +386,24 @@ type InputObjectTypeDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *InputObjectTypeDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *InputObjectTypeDefinition) GetLoc() *Loc { return d.Loc }
+func (d *InputObjectTypeDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+len(d.Fields)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, field := range d.Fields {
+		if field != nil {
+			children = append(children, field)
+		}
+	}
+	return children
+}
 func (*InputObjectTypeDefinition) isDefinition()                 {}
 func (d *InputObjectTypeDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -197,7 +416,21 @@ type InputObjectTypeExtension struct {
 	Comments   *CommentGroup
 }
 
-func (d *InputObjectTypeExtension) GetLoc() *Loc                { return d.Loc }
+func (d *InputObjectTypeExtension) GetLoc() *Loc { return d.Loc }
+func (d *InputObjectTypeExtension) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+len(d.Fields))
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	for _, field := range d.Fields {
+		if field != nil {
+			children = append(children, field)
+		}
+	}
+	return children
+}
 func (*InputObjectTypeExtension) isDefinition()                 {}
 func (d *InputObjectTypeExtension) CommentSlot() **CommentGroup { return &d.Comments }
 
@@ -213,7 +446,27 @@ type FieldDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *FieldDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *FieldDefinition) GetLoc() *Loc { return d.Loc }
+func (d *FieldDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Arguments)+len(d.Directives)+2)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, arg := range d.Arguments {
+		if arg != nil {
+			children = append(children, arg)
+		}
+	}
+	if d.Type != nil {
+		children = append(children, d.Type)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	return children
+}
 func (d *FieldDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // InputValueDefinition is used for both argument definitions (on
@@ -229,7 +482,25 @@ type InputValueDefinition struct {
 	Comments     *CommentGroup
 }
 
-func (d *InputValueDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *InputValueDefinition) GetLoc() *Loc { return d.Loc }
+func (d *InputValueDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+3)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	if d.Type != nil {
+		children = append(children, d.Type)
+	}
+	if d.DefaultValue != nil {
+		children = append(children, d.DefaultValue)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	return children
+}
 func (d *InputValueDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // EnumValueDefinition is one entry inside an EnumTypeDefinition. The Name
@@ -242,7 +513,19 @@ type EnumValueDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *EnumValueDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *EnumValueDefinition) GetLoc() *Loc { return d.Loc }
+func (d *EnumValueDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Directives)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, dir := range d.Directives {
+		if dir != nil {
+			children = append(children, dir)
+		}
+	}
+	return children
+}
 func (d *EnumValueDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 
 // DirectiveDefinition declares a directive: "directive @name(args) on LOCATIONS".
@@ -257,7 +540,19 @@ type DirectiveDefinition struct {
 	Comments    *CommentGroup
 }
 
-func (d *DirectiveDefinition) GetLoc() *Loc                { return d.Loc }
+func (d *DirectiveDefinition) GetLoc() *Loc { return d.Loc }
+func (d *DirectiveDefinition) Children() []Node {
+	children := make([]Node, 0, len(d.Arguments)+1)
+	if d.Description != nil {
+		children = append(children, d.Description)
+	}
+	for _, arg := range d.Arguments {
+		if arg != nil {
+			children = append(children, arg)
+		}
+	}
+	return children
+}
 func (*DirectiveDefinition) isDefinition()                 {}
 func (d *DirectiveDefinition) CommentSlot() **CommentGroup { return &d.Comments }
 

--- a/ast/type.go
+++ b/ast/type.go
@@ -6,8 +6,9 @@ type NamedType struct {
 	Loc  *Loc
 }
 
-func (t *NamedType) GetLoc() *Loc { return t.Loc }
-func (*NamedType) isType()        {}
+func (t *NamedType) GetLoc() *Loc   { return t.Loc }
+func (*NamedType) Children() []Node { return nil }
+func (*NamedType) isType()          {}
 
 // ListType is a [T] type. OfType is the inner type, which may itself be any
 // Type (NamedType, ListType, or NonNullType).
@@ -17,7 +18,13 @@ type ListType struct {
 }
 
 func (t *ListType) GetLoc() *Loc { return t.Loc }
-func (*ListType) isType()        {}
+func (t *ListType) Children() []Node {
+	if t.OfType == nil {
+		return nil
+	}
+	return []Node{t.OfType}
+}
+func (*ListType) isType() {}
 
 // NonNullType is a T! type. Per spec, OfType must be a NamedType or ListType,
 // not another NonNullType — the parser enforces this.
@@ -27,7 +34,13 @@ type NonNullType struct {
 }
 
 func (t *NonNullType) GetLoc() *Loc { return t.Loc }
-func (*NonNullType) isType()        {}
+func (t *NonNullType) Children() []Node {
+	if t.OfType == nil {
+		return nil
+	}
+	return []Node{t.OfType}
+}
+func (*NonNullType) isType() {}
 
 // TypeString returns the canonical type-reference spelling for t, or "" when
 // t is nil, a BadType, or a malformed type reference.

--- a/ast/value.go
+++ b/ast/value.go
@@ -10,6 +10,7 @@ type IntValue struct {
 }
 
 func (v *IntValue) GetLoc() *Loc                { return v.Loc }
+func (*IntValue) Children() []Node              { return nil }
 func (*IntValue) isValue()                      {}
 func (v *IntValue) CommentSlot() **CommentGroup { return &v.Comments }
 
@@ -21,6 +22,7 @@ type FloatValue struct {
 }
 
 func (v *FloatValue) GetLoc() *Loc                { return v.Loc }
+func (*FloatValue) Children() []Node              { return nil }
 func (*FloatValue) isValue()                      {}
 func (v *FloatValue) CommentSlot() **CommentGroup { return &v.Comments }
 
@@ -36,6 +38,7 @@ type StringValue struct {
 }
 
 func (v *StringValue) GetLoc() *Loc                { return v.Loc }
+func (*StringValue) Children() []Node              { return nil }
 func (*StringValue) isValue()                      {}
 func (v *StringValue) CommentSlot() **CommentGroup { return &v.Comments }
 
@@ -47,6 +50,7 @@ type BooleanValue struct {
 }
 
 func (v *BooleanValue) GetLoc() *Loc                { return v.Loc }
+func (*BooleanValue) Children() []Node              { return nil }
 func (*BooleanValue) isValue()                      {}
 func (v *BooleanValue) CommentSlot() **CommentGroup { return &v.Comments }
 
@@ -57,6 +61,7 @@ type NullValue struct {
 }
 
 func (v *NullValue) GetLoc() *Loc                { return v.Loc }
+func (*NullValue) Children() []Node              { return nil }
 func (*NullValue) isValue()                      {}
 func (v *NullValue) CommentSlot() **CommentGroup { return &v.Comments }
 
@@ -68,6 +73,7 @@ type EnumValue struct {
 }
 
 func (v *EnumValue) GetLoc() *Loc                { return v.Loc }
+func (*EnumValue) Children() []Node              { return nil }
 func (*EnumValue) isValue()                      {}
 func (v *EnumValue) CommentSlot() **CommentGroup { return &v.Comments }
 
@@ -78,7 +84,16 @@ type ListValue struct {
 	Comments *CommentGroup
 }
 
-func (v *ListValue) GetLoc() *Loc                { return v.Loc }
+func (v *ListValue) GetLoc() *Loc { return v.Loc }
+func (v *ListValue) Children() []Node {
+	children := make([]Node, 0, len(v.Values))
+	for _, value := range v.Values {
+		if value != nil {
+			children = append(children, value)
+		}
+	}
+	return children
+}
 func (*ListValue) isValue()                      {}
 func (v *ListValue) CommentSlot() **CommentGroup { return &v.Comments }
 
@@ -89,7 +104,16 @@ type ObjectValue struct {
 	Comments *CommentGroup
 }
 
-func (v *ObjectValue) GetLoc() *Loc                { return v.Loc }
+func (v *ObjectValue) GetLoc() *Loc { return v.Loc }
+func (v *ObjectValue) Children() []Node {
+	children := make([]Node, 0, len(v.Fields))
+	for _, field := range v.Fields {
+		if field != nil {
+			children = append(children, field)
+		}
+	}
+	return children
+}
 func (*ObjectValue) isValue()                      {}
 func (v *ObjectValue) CommentSlot() **CommentGroup { return &v.Comments }
 
@@ -101,7 +125,13 @@ type ObjectField struct {
 	Comments *CommentGroup
 }
 
-func (f *ObjectField) GetLoc() *Loc                { return f.Loc }
+func (f *ObjectField) GetLoc() *Loc { return f.Loc }
+func (f *ObjectField) Children() []Node {
+	if f.Value == nil {
+		return nil
+	}
+	return []Node{f.Value}
+}
 func (f *ObjectField) CommentSlot() **CommentGroup { return &f.Comments }
 
 // Variable is a $name reference. It implements Value but the parser refuses
@@ -114,5 +144,6 @@ type Variable struct {
 }
 
 func (v *Variable) GetLoc() *Loc                { return v.Loc }
+func (*Variable) Children() []Node              { return nil }
 func (*Variable) isValue()                      {}
 func (v *Variable) CommentSlot() **CommentGroup { return &v.Comments }

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -8,10 +8,6 @@ type Visitor interface {
 	Visit(node Node) Visitor
 }
 
-type childWalker interface {
-	walkChildren(Visitor)
-}
-
 // Walk performs a depth-first, source-order traversal of node and its
 // children. It does not visit Comments or descend into BadValue/BadType/
 // BadField/BadDefinition placeholder nodes — they are leaves for traversal
@@ -24,13 +20,88 @@ func Walk(v Visitor, node Node) {
 	if v == nil {
 		return
 	}
-	if walker, ok := node.(childWalker); ok {
-		walker.walkChildren(v)
+	if walkBuiltInChildren(v, node) {
 		return
 	}
 	for _, child := range node.Children() {
 		Walk(v, child)
 	}
+}
+
+func walkBuiltInChildren(v Visitor, node Node) bool {
+	switch n := node.(type) {
+	case *Document:
+		n.walkChildren(v)
+	case *OperationDefinition:
+		n.walkChildren(v)
+	case *FragmentDefinition:
+		n.walkChildren(v)
+	case *VariableDefinition:
+		n.walkChildren(v)
+	case *SelectionSet:
+		n.walkChildren(v)
+	case *Field:
+		n.walkChildren(v)
+	case *FragmentSpread:
+		n.walkChildren(v)
+	case *InlineFragment:
+		n.walkChildren(v)
+	case *Argument:
+		n.walkChildren(v)
+	case *Directive:
+		n.walkChildren(v)
+	case *ListValue:
+		n.walkChildren(v)
+	case *ObjectValue:
+		n.walkChildren(v)
+	case *ObjectField:
+		n.walkChildren(v)
+	case *ListType:
+		n.walkChildren(v)
+	case *NonNullType:
+		n.walkChildren(v)
+	case *SchemaDefinition:
+		n.walkChildren(v)
+	case *SchemaExtension:
+		n.walkChildren(v)
+	case *OperationTypeDefinition:
+		n.walkChildren(v)
+	case *ScalarTypeDefinition:
+		n.walkChildren(v)
+	case *ScalarTypeExtension:
+		n.walkChildren(v)
+	case *ObjectTypeDefinition:
+		n.walkChildren(v)
+	case *ObjectTypeExtension:
+		n.walkChildren(v)
+	case *InterfaceTypeDefinition:
+		n.walkChildren(v)
+	case *InterfaceTypeExtension:
+		n.walkChildren(v)
+	case *UnionTypeDefinition:
+		n.walkChildren(v)
+	case *UnionTypeExtension:
+		n.walkChildren(v)
+	case *EnumTypeDefinition:
+		n.walkChildren(v)
+	case *EnumTypeExtension:
+		n.walkChildren(v)
+	case *InputObjectTypeDefinition:
+		n.walkChildren(v)
+	case *InputObjectTypeExtension:
+		n.walkChildren(v)
+	case *FieldDefinition:
+		n.walkChildren(v)
+	case *InputValueDefinition:
+		n.walkChildren(v)
+	case *EnumValueDefinition:
+		n.walkChildren(v)
+	case *DirectiveDefinition:
+		n.walkChildren(v)
+	default:
+		return false
+	}
+	return true
 }
 
 func walkNode(v Visitor, child Node) {

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -8,6 +8,10 @@ type Visitor interface {
 	Visit(node Node) Visitor
 }
 
+type childWalker interface {
+	walkChildren(Visitor)
+}
+
 // Walk performs a depth-first, source-order traversal of node and its
 // children. It does not visit Comments or descend into BadValue/BadType/
 // BadField/BadDefinition placeholder nodes — they are leaves for traversal
@@ -20,289 +24,109 @@ func Walk(v Visitor, node Node) {
 	if v == nil {
 		return
 	}
-	switch n := node.(type) {
-	// Document and executable definitions
-	case *Document:
-		for _, def := range n.Definitions {
-			Walk(v, def)
-		}
-	case *OperationDefinition:
-		for _, vd := range n.VariableDefinitions {
-			Walk(v, vd)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		if n.SelectionSet != nil {
-			Walk(v, n.SelectionSet)
-		}
-	case *FragmentDefinition:
-		if n.TypeCondition != nil {
-			Walk(v, n.TypeCondition)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		if n.SelectionSet != nil {
-			Walk(v, n.SelectionSet)
-		}
-	case *VariableDefinition:
-		if n.Variable != nil {
-			Walk(v, n.Variable)
-		}
-		if n.Type != nil {
-			Walk(v, n.Type)
-		}
-		if n.DefaultValue != nil {
-			Walk(v, n.DefaultValue)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-	case *SelectionSet:
-		for _, s := range n.Selections {
-			Walk(v, s)
-		}
-	case *Field:
-		for _, a := range n.Arguments {
-			Walk(v, a)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		if n.SelectionSet != nil {
-			Walk(v, n.SelectionSet)
-		}
-	case *FragmentSpread:
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-	case *InlineFragment:
-		if n.TypeCondition != nil {
-			Walk(v, n.TypeCondition)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		if n.SelectionSet != nil {
-			Walk(v, n.SelectionSet)
-		}
-	case *Argument:
-		if n.Value != nil {
-			Walk(v, n.Value)
-		}
-	case *Directive:
-		for _, a := range n.Arguments {
-			Walk(v, a)
-		}
+	if walker, ok := node.(childWalker); ok {
+		walker.walkChildren(v)
+		return
+	}
+	for _, child := range node.Children() {
+		Walk(v, child)
+	}
+}
 
-	// Values
-	case *ListValue:
-		for _, val := range n.Values {
-			Walk(v, val)
-		}
-	case *ObjectValue:
-		for _, f := range n.Fields {
-			Walk(v, f)
-		}
-	case *ObjectField:
-		if n.Value != nil {
-			Walk(v, n.Value)
-		}
+func walkNode(v Visitor, child Node) {
+	if child != nil {
+		Walk(v, child)
+	}
+}
 
-	// Types
-	case *ListType:
-		if n.OfType != nil {
-			Walk(v, n.OfType)
-		}
-	case *NonNullType:
-		if n.OfType != nil {
-			Walk(v, n.OfType)
-		}
+func walkDefinitions(v Visitor, children DefinitionList) {
+	for _, child := range children {
+		walkNode(v, child)
+	}
+}
 
-	// Type-system definitions
-	case *SchemaDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, ot := range n.OperationTypes {
-			Walk(v, ot)
-		}
-	case *SchemaExtension:
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, ot := range n.OperationTypes {
-			Walk(v, ot)
-		}
-	case *OperationTypeDefinition:
-		if n.Type != nil {
-			Walk(v, n.Type)
-		}
-
-	case *ScalarTypeDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-	case *ScalarTypeExtension:
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-
-	case *ObjectTypeDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, i := range n.Interfaces {
-			Walk(v, i)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, f := range n.Fields {
-			Walk(v, f)
-		}
-	case *ObjectTypeExtension:
-		for _, i := range n.Interfaces {
-			Walk(v, i)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, f := range n.Fields {
-			Walk(v, f)
-		}
-
-	case *InterfaceTypeDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, i := range n.Interfaces {
-			Walk(v, i)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, f := range n.Fields {
-			Walk(v, f)
-		}
-	case *InterfaceTypeExtension:
-		for _, i := range n.Interfaces {
-			Walk(v, i)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, f := range n.Fields {
-			Walk(v, f)
-		}
-
-	case *UnionTypeDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, m := range n.Members {
-			Walk(v, m)
-		}
-	case *UnionTypeExtension:
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, m := range n.Members {
-			Walk(v, m)
-		}
-
-	case *EnumTypeDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, ev := range n.Values {
-			Walk(v, ev)
-		}
-	case *EnumTypeExtension:
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, ev := range n.Values {
-			Walk(v, ev)
-		}
-
-	case *InputObjectTypeDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, f := range n.Fields {
-			Walk(v, f)
-		}
-	case *InputObjectTypeExtension:
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-		for _, f := range n.Fields {
-			Walk(v, f)
-		}
-
-	case *FieldDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, a := range n.Arguments {
-			Walk(v, a)
-		}
-		if n.Type != nil {
-			Walk(v, n.Type)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-	case *InputValueDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		if n.Type != nil {
-			Walk(v, n.Type)
-		}
-		if n.DefaultValue != nil {
-			Walk(v, n.DefaultValue)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-	case *EnumValueDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, d := range n.Directives {
-			Walk(v, d)
-		}
-	case *DirectiveDefinition:
-		if n.Description != nil {
-			Walk(v, n.Description)
-		}
-		for _, a := range n.Arguments {
-			Walk(v, a)
+func walkVariableDefinitions(v Visitor, children VariableDefinitionList) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
 		}
 	}
-	// Falling through with no case match is a no-op: leaf nodes
-	// (IntValue, FloatValue, StringValue, BooleanValue, NullValue,
-	// EnumValue, Variable, NamedType, Comment, Bad*) have no children,
-	// so simply visiting them and returning is correct. Any future node
-	// kind added without a case here defaults to the same behavior.
+}
+
+func walkSelections(v Visitor, children []Selection) {
+	for _, child := range children {
+		walkNode(v, child)
+	}
+}
+
+func walkArguments(v Visitor, children ArgumentList) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
+		}
+	}
+}
+
+func walkDirectives(v Visitor, children DirectiveList) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
+		}
+	}
+}
+
+func walkValues(v Visitor, children []Value) {
+	for _, child := range children {
+		walkNode(v, child)
+	}
+}
+
+func walkObjectFields(v Visitor, children []*ObjectField) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
+		}
+	}
+}
+
+func walkNamedTypes(v Visitor, children []*NamedType) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
+		}
+	}
+}
+
+func walkOperationTypes(v Visitor, children []*OperationTypeDefinition) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
+		}
+	}
+}
+
+func walkFieldDefinitions(v Visitor, children FieldDefinitionList) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
+		}
+	}
+}
+
+func walkInputValues(v Visitor, children InputValueList) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
+		}
+	}
+}
+
+func walkEnumValues(v Visitor, children EnumValueList) {
+	for _, child := range children {
+		if child != nil {
+			Walk(v, child)
+		}
+	}
 }
 
 // inspector adapts a func(Node) bool to the Visitor interface for Inspect.

--- a/ast/walk_children.go
+++ b/ast/walk_children.go
@@ -1,0 +1,221 @@
+package ast
+
+func (d *Document) walkChildren(v Visitor) {
+	walkDefinitions(v, d.Definitions)
+}
+
+func (d *OperationDefinition) walkChildren(v Visitor) {
+	walkVariableDefinitions(v, d.VariableDefinitions)
+	walkDirectives(v, d.Directives)
+	if d.SelectionSet != nil {
+		Walk(v, d.SelectionSet)
+	}
+}
+
+func (d *FragmentDefinition) walkChildren(v Visitor) {
+	if d.TypeCondition != nil {
+		Walk(v, d.TypeCondition)
+	}
+	walkDirectives(v, d.Directives)
+	if d.SelectionSet != nil {
+		Walk(v, d.SelectionSet)
+	}
+}
+
+func (vdef *VariableDefinition) walkChildren(v Visitor) {
+	if vdef.Variable != nil {
+		Walk(v, vdef.Variable)
+	}
+	walkNode(v, vdef.Type)
+	walkNode(v, vdef.DefaultValue)
+	walkDirectives(v, vdef.Directives)
+}
+
+func (s *SelectionSet) walkChildren(v Visitor) {
+	walkSelections(v, s.Selections)
+}
+
+func (f *Field) walkChildren(v Visitor) {
+	walkArguments(v, f.Arguments)
+	walkDirectives(v, f.Directives)
+	if f.SelectionSet != nil {
+		Walk(v, f.SelectionSet)
+	}
+}
+
+func (s *FragmentSpread) walkChildren(v Visitor) {
+	walkDirectives(v, s.Directives)
+}
+
+func (f *InlineFragment) walkChildren(v Visitor) {
+	if f.TypeCondition != nil {
+		Walk(v, f.TypeCondition)
+	}
+	walkDirectives(v, f.Directives)
+	if f.SelectionSet != nil {
+		Walk(v, f.SelectionSet)
+	}
+}
+
+func (a *Argument) walkChildren(v Visitor) {
+	walkNode(v, a.Value)
+}
+
+func (d *Directive) walkChildren(v Visitor) {
+	walkArguments(v, d.Arguments)
+}
+
+func (vlist *ListValue) walkChildren(v Visitor) {
+	walkValues(v, vlist.Values)
+}
+
+func (vobj *ObjectValue) walkChildren(v Visitor) {
+	walkObjectFields(v, vobj.Fields)
+}
+
+func (f *ObjectField) walkChildren(v Visitor) {
+	walkNode(v, f.Value)
+}
+
+func (t *ListType) walkChildren(v Visitor) {
+	if t.OfType != nil {
+		Walk(v, t.OfType)
+	}
+}
+
+func (t *NonNullType) walkChildren(v Visitor) {
+	if t.OfType != nil {
+		Walk(v, t.OfType)
+	}
+}
+
+func (d *SchemaDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkDirectives(v, d.Directives)
+	walkOperationTypes(v, d.OperationTypes)
+}
+
+func (d *SchemaExtension) walkChildren(v Visitor) {
+	walkDirectives(v, d.Directives)
+	walkOperationTypes(v, d.OperationTypes)
+}
+
+func (d *OperationTypeDefinition) walkChildren(v Visitor) {
+	if d.Type != nil {
+		Walk(v, d.Type)
+	}
+}
+
+func (d *ScalarTypeDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkDirectives(v, d.Directives)
+}
+
+func (d *ScalarTypeExtension) walkChildren(v Visitor) {
+	walkDirectives(v, d.Directives)
+}
+
+func (d *ObjectTypeDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkNamedTypes(v, d.Interfaces)
+	walkDirectives(v, d.Directives)
+	walkFieldDefinitions(v, d.Fields)
+}
+
+func (d *ObjectTypeExtension) walkChildren(v Visitor) {
+	walkNamedTypes(v, d.Interfaces)
+	walkDirectives(v, d.Directives)
+	walkFieldDefinitions(v, d.Fields)
+}
+
+func (d *InterfaceTypeDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkNamedTypes(v, d.Interfaces)
+	walkDirectives(v, d.Directives)
+	walkFieldDefinitions(v, d.Fields)
+}
+
+func (d *InterfaceTypeExtension) walkChildren(v Visitor) {
+	walkNamedTypes(v, d.Interfaces)
+	walkDirectives(v, d.Directives)
+	walkFieldDefinitions(v, d.Fields)
+}
+
+func (d *UnionTypeDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkDirectives(v, d.Directives)
+	walkNamedTypes(v, d.Members)
+}
+
+func (d *UnionTypeExtension) walkChildren(v Visitor) {
+	walkDirectives(v, d.Directives)
+	walkNamedTypes(v, d.Members)
+}
+
+func (d *EnumTypeDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkDirectives(v, d.Directives)
+	walkEnumValues(v, d.Values)
+}
+
+func (d *EnumTypeExtension) walkChildren(v Visitor) {
+	walkDirectives(v, d.Directives)
+	walkEnumValues(v, d.Values)
+}
+
+func (d *InputObjectTypeDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkDirectives(v, d.Directives)
+	walkInputValues(v, d.Fields)
+}
+
+func (d *InputObjectTypeExtension) walkChildren(v Visitor) {
+	walkDirectives(v, d.Directives)
+	walkInputValues(v, d.Fields)
+}
+
+func (d *FieldDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkInputValues(v, d.Arguments)
+	walkNode(v, d.Type)
+	walkDirectives(v, d.Directives)
+}
+
+func (d *InputValueDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkNode(v, d.Type)
+	walkNode(v, d.DefaultValue)
+	walkDirectives(v, d.Directives)
+}
+
+func (d *EnumValueDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkDirectives(v, d.Directives)
+}
+
+func (d *DirectiveDefinition) walkChildren(v Visitor) {
+	if d.Description != nil {
+		Walk(v, d.Description)
+	}
+	walkInputValues(v, d.Arguments)
+}

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -38,6 +38,29 @@ func TestWalk_VisitsRoot(t *testing.T) {
 	}
 }
 
+type customNode struct {
+	children []ast.Node
+}
+
+func (*customNode) GetLoc() *ast.Loc { return nil }
+
+func (n *customNode) Children() []ast.Node { return n.children }
+
+func TestWalk_DescendsIntoCustomNodeChildren(t *testing.T) {
+	child := &ast.IntValue{Value: "1"}
+	root := &customNode{children: []ast.Node{child}}
+
+	r := &recordVisitor{}
+	ast.Walk(r, root)
+
+	if len(r.visited) != 2 {
+		t.Fatalf("visited %d nodes; want root and child", len(r.visited))
+	}
+	if r.visited[0] != root || r.visited[1] != child {
+		t.Fatalf("visited %#v; want root then child", r.visited)
+	}
+}
+
 func TestWalk_StopOnNil(t *testing.T) {
 	doc, err := parser.Parse("{ x { y } }")
 	if err != nil {

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -61,6 +61,36 @@ func TestWalk_DescendsIntoCustomNodeChildren(t *testing.T) {
 	}
 }
 
+type customDocumentWrapper struct {
+	*ast.Document
+	children []ast.Node
+}
+
+func (n *customDocumentWrapper) Children() []ast.Node { return n.children }
+
+func TestWalk_UsesCustomChildrenForEmbeddedBuiltInNode(t *testing.T) {
+	child := &ast.IntValue{Value: "1"}
+	embedded := &ast.Document{
+		Definitions: ast.DefinitionList{&ast.OperationDefinition{
+			SelectionSet: &ast.SelectionSet{},
+		}},
+	}
+	root := &customDocumentWrapper{
+		Document: embedded,
+		children: []ast.Node{child},
+	}
+
+	r := &recordVisitor{}
+	ast.Walk(r, root)
+
+	if len(r.visited) != 2 {
+		t.Fatalf("visited %d nodes; want root and custom child: %#v", len(r.visited), r.visited)
+	}
+	if r.visited[0] != root || r.visited[1] != child {
+		t.Fatalf("visited %#v; want root then custom child", r.visited)
+	}
+}
+
 func TestWalk_MatchesRecursiveChildrenOrderForBuiltInNodes(t *testing.T) {
 	doc, err := parser.Parse(`
 		query Q($v: [Int!]! = [1]) @trace(arg: {nested: [true, null, ENUM]}) {

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -61,6 +61,72 @@ func TestWalk_DescendsIntoCustomNodeChildren(t *testing.T) {
 	}
 }
 
+func TestWalk_MatchesRecursiveChildrenOrderForBuiltInNodes(t *testing.T) {
+	doc, err := parser.Parse(`
+		query Q($v: [Int!]! = [1]) @trace(arg: {nested: [true, null, ENUM]}) {
+			field(arg: {a: [1], v: $v}) {
+				...Frag
+				... on T @include(if: false) { id }
+			}
+		}
+		fragment Frag on T @frag { other }
+
+		"""schema desc"""
+		schema @schemaDir { query: Query mutation: Mutation subscription: Subscription }
+		"""scalar desc"""
+		scalar Date @scalar
+		"""object desc"""
+		type T implements I @obj {
+			"""field desc"""
+			f("""arg desc""" a: [Int!] = {k: [1]} @arg): String @field
+		}
+		"""interface desc"""
+		interface I implements J @iface { id: ID }
+		"""union desc"""
+		union U @union = T | Query
+		"""enum desc"""
+		enum E @enum { """A desc""" A @value }
+		"""input desc"""
+		input In @input { """in desc""" x: Int = 1 @inputField }
+		"""directive desc"""
+		directive @dir(arg: String = "x") repeatable on FIELD | QUERY
+		extend schema @ext { mutation: Mutation }
+		extend scalar Date @ext
+		extend type T implements J @ext { g: Int }
+		extend interface I implements J @ext { g: Int }
+		extend union U @ext = Other
+		extend enum E @ext { B }
+		extend input In @ext { y: Int }
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := parser.ParseValue(`{a: [1, "hi", $v, ENUM, true, null], b: {nested: 1}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typ, err := parser.ParseType("[[Int!]!]!")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		root ast.Node
+	}{
+		{name: "document", root: doc},
+		{name: "value", root: value},
+		{name: "type", root: typ},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectViaWalk(tt.root)
+			want := collectViaChildren(tt.root)
+			assertSameNodes(t, got, want)
+		})
+	}
+}
+
 func TestWalk_StopOnNil(t *testing.T) {
 	doc, err := parser.Parse("{ x { y } }")
 	if err != nil {
@@ -188,6 +254,35 @@ func TestInspect_StopOnFalse(t *testing.T) {
 	})
 	if depth != 1 {
 		t.Errorf("expected to count exactly one Field; got %d", depth)
+	}
+}
+
+func collectViaWalk(root ast.Node) []ast.Node {
+	r := &recordVisitor{}
+	ast.Walk(r, root)
+	return r.visited
+}
+
+func collectViaChildren(root ast.Node) []ast.Node {
+	if root == nil {
+		return nil
+	}
+	nodes := []ast.Node{root}
+	for _, child := range root.Children() {
+		nodes = append(nodes, collectViaChildren(child)...)
+	}
+	return nodes
+}
+
+func assertSameNodes(t *testing.T, got, want []ast.Node) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("visited %d nodes; want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("node[%d] = %T(%p); want %T(%p)", i, got[i], got[i], want[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Refactors AST traversal so `Walk` and `Inspect` dispatch through per-node child traversal methods instead of keeping the child-walking logic inside one large recursive type switch.

Closes #4.

## Implementation

- Adds node-local child traversal helpers across document, executable, schema, type, value, bad-node, and comment-bearing AST structs.
- Reworks `ast.Walk` to keep visitor enter/leave behavior while delegating child ordering to generated-style node methods.
- Preserves the existing traversal order and nil-handling semantics with parity tests for built-in non-leaf nodes.
- Adds traversal benchmarks and focused tests around child order and recursive walk equivalence.

## Verification

- `go test ./ast -run 'TestWalk_MatchesRecursiveChildrenOrderForBuiltInNodes|TestChildren_OrderForNonLeafNodes' -count=1`
- `go test ./ast ./parser`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `go test -bench=BenchmarkWalk -benchmem -run=- ./ast`
- `go test -bench=. -benchmem -run=- ./parser/`
- Hot-path grep for `regexp`, `reflect`, and `fmt.Sprintf` found only existing error formatting and test-only reflection.
